### PR TITLE
Add basic game menu

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -29,11 +29,40 @@ button:hover {
   margin-bottom: 1.5rem;
 }
 
-#asciiChart {
-  white-space: pre;
-  background: #111;
-  padding: 0.5rem;
-  border: 1px solid #33ff33;
-  font-size: 0.85rem;
-  line-height: 1.1rem;
+
+.status {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.status div {
+  min-width: 120px;
+}
+
+.menu {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+.menu button {
+  width: 100%;
+}
+
+@media (min-width: 600px) {
+  .menu {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: none;
+  }
+  .menu button {
+    flex: 1 0 150px;
+  }
 }

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -1,0 +1,54 @@
+const gameState = {
+  week: 14,
+  maxWeeks: 104,
+  cash: 35000,
+  netWorth: 35000,
+  rank: 'Novice'
+};
+
+function updateStatus() {
+  document.getElementById('week').textContent = gameState.week;
+  document.getElementById('rank').textContent = gameState.rank;
+  document.getElementById('netWorth').textContent = gameState.netWorth.toLocaleString();
+  document.getElementById('cash').textContent = gameState.cash.toLocaleString();
+}
+
+function updateRank() {
+  const worth = gameState.netWorth;
+  if (worth > 1000000) {
+    gameState.rank = 'Tycoon';
+  } else if (worth > 250000) {
+    gameState.rank = 'Trader';
+  } else if (worth > 100000) {
+    gameState.rank = 'Apprentice';
+  } else {
+    gameState.rank = 'Novice';
+  }
+}
+
+function nextWeek() {
+  if (gameState.week >= gameState.maxWeeks) {
+    alert('Game over');
+    return;
+  }
+  gameState.week += 1;
+  // simple demo economic change
+  const change = Math.floor(Math.random() * 1500 - 500);
+  gameState.cash += change;
+  gameState.netWorth += change;
+  updateRank();
+  updateStatus();
+}
+
+function showPlaceholder(msg) {
+  alert(msg + ' screen goes here.');
+}
+
+document.getElementById('doneBtn').addEventListener('click', nextWeek);
+document.getElementById('newsBtn').addEventListener('click', () => showPlaceholder('News'));
+document.getElementById('dataBtn').addEventListener('click', () => showPlaceholder('Data'));
+document.getElementById('portfolioBtn').addEventListener('click', () => showPlaceholder('Portfolio'));
+document.getElementById('tradeBtn').addEventListener('click', () => showPlaceholder('Trade'));
+
+updateStatus();
+

--- a/docs/play.html
+++ b/docs/play.html
@@ -6,28 +6,20 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-
-  <h1>Drawdown (Demo)</h1>
-
-  <div class="section">
-    <p><strong>Week:</strong> <span id="week">1</span></p>
-    <p><strong>Net Worth:</strong> $<span id="netWorth">10000</span></p>
-    <button onclick="nextWeek()">Advance Week</button>
+  <h1>Drawdown</h1>
+  <div id="status" class="status">
+    <div>Week: <span id="week">14</span></div>
+    <div>Rank: <span id="rank">Novice</span></div>
+    <div>Net Worth: $<span id="netWorth">35000</span></div>
+    <div>Cash: $<span id="cash">35000</span></div>
   </div>
-
-  <pre id="asciiChart"></pre>
-
-  <div class="section">
-    <button onclick="saveGame()">Save Game</button>
-    <button onclick="loadGame()">Load Game</button>
-    <button onclick="resetGame()">Reset</button>
+  <div class="menu">
+    <button id="newsBtn">news</button>
+    <button id="dataBtn">data</button>
+    <button id="portfolioBtn">portfolio</button>
+    <button id="tradeBtn">trade</button>
+    <button id="doneBtn">done</button>
   </div>
-
-  <div class="section">
-    <button onclick="exportSave()">Download Save</button>
-    <input type="file" id="fileInput" />
-  </div>
-
-  <script src="js/main.js"></script>
+  <script src="js/game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add retro menu layout on `play.html`
- implement menu logic in `game.js`
- style menu for phones and desktops

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685bd16d29c08325b66302ef26e56c0d