### PR TITLE
Update index page with start-game and about links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -69,21 +69,21 @@
       margin-bottom: 1rem;
     }
 
-    .readme-link {
+    .link {
       font-size: 0.95rem;
       color: #33ff33;
       text-decoration: none;
       position: relative;
     }
 
-    .readme-link::after {
+    .link:hover {
+      color: #66ff66;
+    }
+
+    .blink-link::after {
       content: "█";
       animation: blink 1s step-start infinite;
       margin-left: 6px;
-    }
-
-    .readme-link:hover {
-      color: #66ff66;
     }
 
     @keyframes blink {
@@ -122,9 +122,13 @@
         Fake trades. Fake money. Fake market. <br>Real regret.
       </div>
       <div>
-        <a class="readme-link" href="https://github.com/sdrasco/drawdowngame/blob/main/README.md" target="_blank">
-        <!a class="readme-link" href="https://drawdowngame.com/play.html" target="_blank">
-          Get in the game
+        <a class="link blink-link" href="play.html" onclick="localStorage.removeItem('drawdownSave');">
+          Start new game
+        </a>
+      </div>
+      <div>
+        <a class="link" href="https://github.com/sdrasco/drawdowngame/blob/main/README.md" target="_blank">
+          About / Under the hood
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update `index.html` to offer two links
  - **Start new game** clears any save and loads `play.html`
  - **About / Under the hood** opens the GitHub README
- refactor link styling to support blinking cursor effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bd748574c83259167e7ad004bd729