### PR TITLE
Update game menu text and layout

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -55,6 +55,10 @@ button:hover {
   width: 100%;
 }
 
+.menu button.advance {
+  width: 100%;
+}
+
 @media (max-width: 600px) {
   body {
     font-size: 1.2rem;
@@ -74,5 +78,8 @@ button:hover {
   }
   .menu button {
     flex: 1 0 150px;
+  }
+  .menu button.advance {
+    flex-basis: 100%;
   }
 }

--- a/docs/play.html
+++ b/docs/play.html
@@ -14,11 +14,11 @@
     <div>Cash: $<span id="cash">35000</span></div>
   </div>
   <div class="menu">
-    <button id="newsBtn">news</button>
-    <button id="dataBtn">data</button>
-    <button id="portfolioBtn">portfolio</button>
-    <button id="tradeBtn">trade</button>
-    <button id="doneBtn">done</button>
+    <button id="newsBtn">News</button>
+    <button id="dataBtn">Analysis</button>
+    <button id="portfolioBtn">Portfolio</button>
+    <button id="tradeBtn">Trade</button>
+    <button id="doneBtn" class="advance">Advance to Next Week</button>
   </div>
   <script src="js/game.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- update play.html menu button text
- style the "Advance to Next Week" button to span its own row

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685bee1aee4c8325948a2bb87f133ea9