### PR TITLE
Remove heading and arrange status grid

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -31,15 +31,15 @@ button:hover {
 
 
 .status {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem 1rem;
   margin-bottom: 1.5rem;
 }
 
 .status div {
   min-width: 120px;
+  text-align: center;
 }
 
 .menu {

--- a/docs/play.html
+++ b/docs/play.html
@@ -6,7 +6,6 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1>Drawdown</h1>
   <div id="status" class="status">
     <div>Week: <span id="week">14</span></div>
     <div>Rank: <span id="rank">Novice</span></div>


### PR DESCRIPTION
## Summary
- drop the top heading on the play page
- display week, rank, net worth, and cash in a 2x2 grid

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685bf0b657988325ba358bda5051a3ee