### PR TITLE
Add market graph and news slots to play page

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -83,3 +83,26 @@ button:hover {
     flex-basis: 100%;
   }
 }
+
+.chart-wrapper {
+  margin: 1rem auto;
+  max-width: 300px;
+  border: 1px solid #33ff33;
+}
+
+#marketChart {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: #000;
+}
+
+.news {
+  margin: 1rem auto;
+  max-width: 300px;
+  min-height: 4.5rem;
+}
+
+.news .headline {
+  margin: 0.25rem 0;
+}

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -38,6 +38,8 @@ function nextWeek() {
   gameState.netWorth += change;
   updateRank();
   updateStatus();
+  updateMarket();
+  renderNews();
 }
 
 function showPlaceholder(msg) {
@@ -53,4 +55,6 @@ document.getElementById('portfolioBtn').addEventListener('click', () => showPlac
 document.getElementById('tradeBtn').addEventListener('click', () => showPlaceholder('Trade'));
 
 updateStatus();
+renderMarketChart();
+renderNews();
 

--- a/docs/js/market.js
+++ b/docs/js/market.js
@@ -1,0 +1,37 @@
+
+// Simple placeholder market history
+const marketHistory = [100];
+
+function renderMarketChart() {
+  const canvas = document.getElementById('marketChart');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const min = Math.min(...marketHistory);
+  const max = Math.max(...marketHistory);
+  const range = max - min || 1;
+
+  ctx.strokeStyle = '#33ff33';
+  ctx.beginPath();
+  marketHistory.forEach((val, idx) => {
+    const x = (idx / (marketHistory.length - 1)) * (canvas.width - 1);
+    const y = canvas.height - ((val - min) / range) * canvas.height;
+    if (idx === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  });
+  ctx.stroke();
+}
+
+function updateMarket() {
+  const last = marketHistory[marketHistory.length - 1];
+  const change = Math.random() * 4 - 2; // random walk
+  marketHistory.push(last + change);
+  if (marketHistory.length > 30) {
+    marketHistory.shift();
+  }
+  renderMarketChart();
+}

--- a/docs/js/news.js
+++ b/docs/js/news.js
@@ -1,0 +1,22 @@
+// Placeholder headlines for demo
+const headlinePool = [
+  'Economy shows signs of recovery',
+  'Tech stocks rally on earnings beat',
+  'Oil prices dip amid oversupply fears',
+  'Consumer confidence hits record high',
+  'Federal Reserve hints at rate cuts',
+  'Manufacturing slows in latest report'
+];
+
+function renderNews() {
+  const container = document.getElementById('news');
+  if (!container) return;
+  container.innerHTML = '';
+  const headlines = headlinePool.sort(() => 0.5 - Math.random()).slice(0, 4);
+  headlines.forEach(text => {
+    const div = document.createElement('div');
+    div.className = 'headline';
+    div.textContent = text;
+    container.appendChild(div);
+  });
+}

--- a/docs/play.html
+++ b/docs/play.html
@@ -12,12 +12,18 @@
     <div>Net Worth: $<span id="netWorth">35000</span></div>
     <div>Cash: $<span id="cash">35000</span></div>
   </div>
+  <div class="chart-wrapper">
+    <canvas id="marketChart" width="300" height="150"></canvas>
+  </div>
+  <div id="news" class="news"></div>
   <div class="menu">
     <button id="dataBtn">Analysis</button>
     <button id="portfolioBtn">Portfolio</button>
     <button id="tradeBtn">Trade</button>
     <button id="doneBtn" class="advance">Advance to Next Week</button>
   </div>
+  <script src="js/market.js"></script>
+  <script src="js/news.js"></script>
   <script src="js/game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a simple market index graph canvas on the game page
- add news section for up to four headlines
- create minimal JS to render placeholder chart and headlines
- wire new scripts into the game logic
- style the graph and news sections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bf3de4180832594afa1530e517014