### PR TITLE
Add persistent state and headlines

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -1,10 +1,15 @@
-const gameState = {
-  week: 14,
-  maxWeeks: 104,
-  cash: 35000,
-  netWorth: 35000,
-  rank: 'Novice'
-};
+let gameState = loadState();
+if (!gameState) {
+  gameState = {
+    week: 14,
+    maxWeeks: 104,
+    cash: 35000,
+    netWorth: 35000,
+    rank: 'Novice',
+    headlines: {}
+  };
+  saveState(gameState);
+}
 
 function updateStatus() {
   document.getElementById('week').textContent = gameState.week;
@@ -39,6 +44,7 @@ function nextWeek() {
   updateRank();
   updateStatus();
   updateMarket();
+  saveState(gameState);
   renderNews();
 }
 

--- a/docs/js/news.js
+++ b/docs/js/news.js
@@ -12,7 +12,12 @@ function renderNews() {
   const container = document.getElementById('news');
   if (!container) return;
   container.innerHTML = '';
-  const headlines = headlinePool.sort(() => 0.5 - Math.random()).slice(0, 4);
+  let headlines = gameState.headlines[gameState.week];
+  if (!headlines) {
+    headlines = headlinePool.sort(() => 0.5 - Math.random()).slice(0, 4);
+    gameState.headlines[gameState.week] = headlines;
+    saveState(gameState);
+  }
   headlines.forEach(text => {
     const div = document.createElement('div');
     div.className = 'headline';

--- a/docs/js/storage.js
+++ b/docs/js/storage.js
@@ -1,0 +1,15 @@
+function loadState() {
+  const saved = localStorage.getItem('drawdownSave');
+  if (!saved) {
+    return null;
+  }
+  try {
+    return JSON.parse(saved);
+  } catch {
+    return null;
+  }
+}
+
+function saveState(state) {
+  localStorage.setItem('drawdownSave', JSON.stringify(state));
+}

--- a/docs/play.html
+++ b/docs/play.html
@@ -22,6 +22,7 @@
     <button id="tradeBtn">Trade</button>
     <button id="doneBtn" class="advance">Advance to Next Week</button>
   </div>
+  <script src="js/storage.js"></script>
   <script src="js/market.js"></script>
   <script src="js/news.js"></script>
   <script src="js/game.js"></script>


### PR DESCRIPTION
## Summary
- implement `loadState` and `saveState` for localStorage
- load saved game data on startup and include per-week headlines
- persist state when advancing weeks
- reuse stored headlines instead of re-randomizing
- include storage script on `play.html`

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685bf775c6f88325a3e10bfd1d3ac689