### PR TITLE
Adjust chart width on play page

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -84,9 +84,10 @@ button:hover {
   }
 }
 
+# chart area
 .chart-wrapper {
   margin: 1rem auto;
-  max-width: 300px;
+  max-width: 500px; /* wider market chart */
   border: 1px solid #33ff33;
 }
 

--- a/docs/play.html
+++ b/docs/play.html
@@ -13,7 +13,7 @@
     <div>Cash: $<span id="cash">35000</span></div>
   </div>
   <div class="chart-wrapper">
-    <canvas id="marketChart" width="300" height="150"></canvas>
+    <canvas id="marketChart" width="500" height="250"></canvas>
   </div>
   <div id="news" class="news"></div>
   <div class="menu">


### PR DESCRIPTION
## Summary
- widen the market chart to use up more screen space

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685bfd831904832582e1ee07e86c13e0