### PR TITLE
Improve layout for play page

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -70,40 +70,31 @@ button:hover {
 }
 
 @media (min-width: 600px) {
+  /* Keep buttons stacked vertically on larger screens */
   .menu {
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    max-width: none;
-  }
-  .menu button {
-    flex: 1 0 150px;
-  }
-  .menu button.advance {
-    flex-basis: 100%;
+    max-width: 300px;
   }
 }
 
-# chart area
 .chart-wrapper {
   margin: 1rem auto;
-  max-width: 500px; /* wider market chart */
+  max-width: 600px;
   border: 1px solid #33ff33;
 }
 
 #marketChart {
   display: block;
   width: 100%;
-  height: auto;
+  height: 350px;
   background: #000;
 }
 
 .news {
   margin: 1rem auto;
-  max-width: 300px;
+  max-width: 600px;
   min-height: 4.5rem;
 }
 
 .news .headline {
-  margin: 0.25rem 0;
+  margin: 0.5rem 0;
 }

--- a/docs/play.html
+++ b/docs/play.html
@@ -13,7 +13,7 @@
     <div>Cash: $<span id="cash">35000</span></div>
   </div>
   <div class="chart-wrapper">
-    <canvas id="marketChart" width="500" height="250"></canvas>
+    <canvas id="marketChart" width="600" height="350"></canvas>
   </div>
   <div id="news" class="news"></div>
   <div class="menu">


### PR DESCRIPTION
## Summary
- keep the play page menu stacked vertically on all screens
- enlarge the market chart area
- make the news section match the chart width and space headlines more

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c00956770832596fd5cd70a98b514