### PR TITLE
Add user-specific storage and price history

### DIFF
--- a/docs/js/storage.js
+++ b/docs/js/storage.js
@@ -1,5 +1,22 @@
+function getUser() {
+  let user = localStorage.getItem('drawdownUser');
+  if (!user) {
+    user = prompt('Enter a username');
+    if (user) {
+      localStorage.setItem('drawdownUser', user);
+    } else {
+      user = 'default';
+    }
+  }
+  return user;
+}
+
+function getStorageKey() {
+  return 'drawdownSave_' + getUser();
+}
+
 function loadState() {
-  const saved = localStorage.getItem('drawdownSave');
+  const saved = localStorage.getItem(getStorageKey());
   if (!saved) {
     return null;
   }
@@ -11,5 +28,5 @@ function loadState() {
 }
 
 function saveState(state) {
-  localStorage.setItem('drawdownSave', JSON.stringify(state));
+  localStorage.setItem(getStorageKey(), JSON.stringify(state));
 }


### PR DESCRIPTION
## Summary
- add per-user save slots in `storage.js`
- fetch company list and generate weekly stock prices in `game.js`
- extend game state with `prices` for each company and update prices each week

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c11199a4c832581fa038052200123