### PR TITLE
Improve username input

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -125,3 +125,27 @@ button:hover {
   font-weight: bold;
   margin-top: 1rem;
 }
+
+.username-prompt {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.username-prompt form {
+  background: #000;
+  border: 1px solid #33ff33;
+  padding: 1rem;
+  text-align: center;
+}
+
+.hidden {
+  display: none;
+}

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -8,7 +8,9 @@ fetch('data/company_master_data.json')
   .then(data => {
     companies = data.companies;
     setupMarketIndex();
-    startGame();
+    ensureUser(() => {
+      startGame();
+    });
   });
 
 function randPct(mu, sigma) {

--- a/docs/js/storage.js
+++ b/docs/js/storage.js
@@ -1,14 +1,41 @@
 function getUser() {
-  let user = localStorage.getItem('drawdownUser');
-  if (!user) {
-    user = prompt('Enter a username');
-    if (user) {
-      localStorage.setItem('drawdownUser', user);
-    } else {
-      user = 'default';
+  return localStorage.getItem('drawdownUser');
+}
+
+function promptForUser(callback) {
+  const promptEl = document.getElementById('usernamePrompt');
+  const inputEl = document.getElementById('usernameInput');
+  const submitBtn = document.getElementById('usernameSubmit');
+
+  function submit() {
+    let value = inputEl.value.trim();
+    if (!value) value = 'default';
+    localStorage.setItem('drawdownUser', value);
+    promptEl.classList.add('hidden');
+    submitBtn.removeEventListener('click', submit);
+    inputEl.removeEventListener('keypress', keyHandler);
+    callback(value);
+  }
+
+  function keyHandler(e) {
+    if (e.key === 'Enter') {
+      submit();
     }
   }
-  return user;
+
+  submitBtn.addEventListener('click', submit);
+  inputEl.addEventListener('keypress', keyHandler);
+  promptEl.classList.remove('hidden');
+  inputEl.focus();
+}
+
+function ensureUser(callback) {
+  const user = getUser();
+  if (user) {
+    callback(user);
+  } else {
+    promptForUser(callback);
+  }
 }
 
 function getStorageKey() {

--- a/docs/play.html
+++ b/docs/play.html
@@ -24,6 +24,13 @@
     <button id="doneBtn" class="advance">Advance to Next Week</button>
   </div>
   <div id="username" class="username"></div>
+  <div id="usernamePrompt" class="username-prompt hidden">
+    <form>
+      <label for="usernameInput">Enter a username</label><br/>
+      <input id="usernameInput" type="text" autocomplete="off" /><br/>
+      <button type="button" id="usernameSubmit">Start</button>
+    </form>
+  </div>
   <script src="js/storage.js"></script>
   <script src="js/market.js"></script>
   <script src="js/news.js"></script>


### PR DESCRIPTION
## Summary
- add non-modal username overlay
- style username overlay
- replace blocking prompt with custom input handler
- wait for username before starting the game

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685c4b8d225c8325b9ca958bf8d642b9