### PR TITLE
Add high scores page

### DIFF
--- a/docs/high-scores.html
+++ b/docs/high-scores.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drawdown - High Scores</title>
+  <style>
+    body {
+      background-color: #000;
+      color: #33ff33;
+      font-family: 'Courier New', Courier, monospace;
+      margin: 0;
+      padding: 40px 20px;
+      text-align: center;
+    }
+    h1 {
+      margin-bottom: 40px;
+      font-size: 2rem;
+    }
+    table {
+      margin: 0 auto;
+      border-collapse: collapse;
+      width: 100%;
+      max-width: 400px;
+    }
+    th, td {
+      border: 1px solid #33ff33;
+      padding: 8px;
+    }
+    a {
+      color: #33ff33;
+    }
+  </style>
+</head>
+<body>
+  <h1>High Scores</h1>
+  <table id="scoresTable"></table>
+  <p><a href="index.html">Back</a></p>
+  <script src="js/highscores.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,6 +121,9 @@
       <a class="link-wrapper" href="play.html" onclick="localStorage.clear();">
         New Game
       </a>
+      <a class="link-wrapper" href="high-scores.html">
+        High Scores
+      </a>
       <a class="link-wrapper" href="https://github.com/sdrasco/drawdowngame/blob/main/README.md" target="_blank">
         About
       </a>

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -113,6 +113,11 @@ function updateRank() {
 function nextWeek() {
   if (gameState.week >= gameState.maxWeeks) {
     alert('Game over');
+    if (window.drawdownHighScores) {
+      window.drawdownHighScores.check(gameState.netWorth, () => {
+        window.location.href = 'high-scores.html';
+      });
+    }
     return;
   }
   gameState.week += 1;

--- a/docs/js/highscores.js
+++ b/docs/js/highscores.js
@@ -1,0 +1,78 @@
+(function() {
+  const STORAGE_KEY = 'drawdownHighScores';
+  const MAX_SCORES = 10;
+
+  function loadScores() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    try { return JSON.parse(raw); } catch { return null; }
+  }
+
+  function saveScores(scores) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(scores));
+  }
+
+  function initScores() {
+    let scores = loadScores();
+    if (scores) return scores;
+    scores = [];
+    fetch('data/random_names.json')
+      .then(r => r.json())
+      .then(names => {
+        for (let i = 0; i < MAX_SCORES; i++) {
+          const name = names[Math.floor(Math.random() * names.length)];
+          const score = Math.floor(Math.random() * 500000 + 5000);
+          scores.push({ name, score });
+        }
+        scores.sort((a,b) => b.score - a.score);
+        saveScores(scores);
+        render(scores);
+      });
+    return scores;
+  }
+
+  function render(scores) {
+    const tbl = document.getElementById('scoresTable');
+    if (!tbl) return;
+    tbl.innerHTML = '';
+    const header = document.createElement('tr');
+    header.innerHTML = '<th>Rank</th><th>Name</th><th>Net Worth</th>';
+    tbl.appendChild(header);
+    scores.forEach((s, idx) => {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${idx + 1}</td><td>${s.name}</td><td>$${s.score.toLocaleString()}</td>`;
+      tbl.appendChild(row);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const scores = loadScores();
+    if (scores) {
+      render(scores);
+    } else {
+      initScores();
+    }
+  });
+
+  window.drawdownHighScores = {
+    check(score, callback) {
+      let scores = loadScores() || initScores();
+      const lowest = scores[scores.length - 1].score;
+      if (scores.length < MAX_SCORES || score > lowest) {
+        const name = prompt('High score! Enter your name:', localStorage.getItem('drawdownUser') || '');
+        if (name !== null) {
+          if (name.trim()) {
+            localStorage.setItem('drawdownUser', name.trim());
+          }
+          scores.push({ name: localStorage.getItem('drawdownUser'), score });
+          scores.sort((a,b) => b.score - a.score);
+          scores = scores.slice(0, MAX_SCORES);
+          saveScores(scores);
+          if (callback) callback();
+        }
+      } else {
+        if (callback) callback();
+      }
+    }
+  };
+})();

--- a/docs/play.html
+++ b/docs/play.html
@@ -35,6 +35,7 @@
   <script src="js/storage.js"></script>
   <script src="js/market.js"></script>
   <script src="js/news.js"></script>
+  <script src="js/highscores.js"></script>
   <script src="js/game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add link for high scores on landing page
- create high-scores page and JS logic
- integrate high score check into game flow
- load highscores script on play page

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685c5c48557083258962a4a688236133