### PR TITLE
Add cash out and display max week

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -85,6 +85,8 @@ function startGame() {
 
 function updateStatus() {
   document.getElementById('week').textContent = gameState.week;
+  const maxEl = document.getElementById('maxWeek');
+  if (maxEl) maxEl.textContent = gameState.maxWeeks;
   document.getElementById('rank').textContent = gameState.rank;
   document.getElementById('netWorth').textContent = gameState.netWorth.toLocaleString();
   document.getElementById('cash').textContent = gameState.cash.toLocaleString();
@@ -142,6 +144,17 @@ function nextWeek() {
   renderNews();
 }
 
+function cashOut() {
+  alert('Game over');
+  if (window.drawdownHighScores) {
+    window.drawdownHighScores.check(gameState.netWorth, () => {
+      window.location.href = 'high-scores.html';
+    });
+  } else {
+    window.location.href = 'high-scores.html';
+  }
+}
+
 function showPlaceholder(msg) {
   alert(msg + ' screen goes here.');
 }
@@ -153,4 +166,5 @@ document.getElementById('dataBtn').addEventListener('click', () => showPlacehold
 // sharpe ratio, and gain to pain ratio.
 document.getElementById('portfolioBtn').addEventListener('click', () => showPlaceholder('Portfolio'));
 document.getElementById('tradeBtn').addEventListener('click', () => showPlaceholder('Trade'));
+document.getElementById('cashOutBtn').addEventListener('click', cashOut);
 

--- a/docs/play.html
+++ b/docs/play.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div id="status" class="status">
-    <div>Week: <span id="week">14</span></div>
+    <div>Week: <span id="week">14</span>/<span id="maxWeek">104</span></div>
     <div>Net Worth: $<span id="netWorth">35000</span></div>
     <div>Rank: <span id="rank">Novice</span></div>
     <div>Cash: $<span id="cash">35000</span></div>
@@ -22,6 +22,7 @@
     <button id="portfolioBtn">Portfolio</button>
     <button id="tradeBtn">Trade</button>
     <button id="doneBtn" class="advance">Advance to Next Week</button>
+    <button id="cashOutBtn">Cash Out</button>
   </div>
   <div id="username" class="username"></div>
   <div id="usernamePrompt" class="username-prompt hidden">


### PR DESCRIPTION
## Summary
- show the maximum week on the play page
- add a Cash Out button so players can exit early

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685c64604c708325a245fc2afcdcfc53