### PR TITLE
Prompt for new high score name

### DIFF
--- a/docs/play.html
+++ b/docs/play.html
@@ -33,6 +33,14 @@
       <button type="button" id="usernameRandom">Random Name</button>
     </form>
   </div>
+  <div id="scorePrompt" class="username-prompt hidden">
+    <form>
+      <label for="scoreInput">High score name</label><br/>
+      <input id="scoreInput" type="text" autocomplete="off" /><br/>
+      <button type="button" id="scoreSubmit">Save</button>
+      <button type="button" id="scoreRandom">Random Name</button>
+    </form>
+  </div>
   <script src="js/storage.js"></script>
   <script src="js/market.js"></script>
   <script src="js/news.js"></script>


### PR DESCRIPTION
## Summary
- allow player to enter a name before submitting a high score
- reuse retro name prompt styling for the leaderboard entry

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d2502dc6883259affb18a5b174446