### PR TITLE
Improve mobile header readability

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -75,9 +75,13 @@ button:hover {
   button {
     font-size: 1.2rem;
   }
-  .status,
   .news {
     font-size: 1.2rem;
+  }
+
+  /* Keep the status header small to avoid clutter */
+  .status {
+    font-size: 0.8rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust mobile layout so the status header uses a smaller font

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d28ec8bac8325bc5036475df6300a