### PR TITLE
Implement trading and portfolio tracking

### DIFF
--- a/docs/js/portfolio.js
+++ b/docs/js/portfolio.js
@@ -1,0 +1,30 @@
+let gameState;
+
+document.addEventListener('DOMContentLoaded', () => {
+  gameState = loadState();
+  if (!gameState) return;
+  if (!gameState.positions) gameState.positions = {};
+  computeNetWorth(gameState);
+  document.getElementById('pNetWorth').textContent = gameState.netWorth.toLocaleString();
+  document.getElementById('pCash').textContent = gameState.cash.toLocaleString();
+  renderPositions();
+});
+
+function renderPositions() {
+  const tbl = document.getElementById('positionsTable');
+  tbl.innerHTML = '';
+  const header = document.createElement('tr');
+  header.innerHTML = '<th>Symbol</th><th>Qty</th><th>Value</th>';
+  tbl.appendChild(header);
+  Object.keys(gameState.positions).forEach(sym => {
+    const pos = gameState.positions[sym];
+    const weeks = gameState.prices[sym];
+    if (!weeks) return;
+    const week = weeks[weeks.length - 1];
+    const price = week[week.length - 1];
+    const row = document.createElement('tr');
+    const value = (pos.qty * price).toFixed(2);
+    row.innerHTML = `<td>${sym}</td><td>${pos.qty}</td><td>$${parseFloat(value).toLocaleString()}</td>`;
+    tbl.appendChild(row);
+  });
+}

--- a/docs/play.html
+++ b/docs/play.html
@@ -41,9 +41,21 @@
       <button type="button" id="scoreRandom">Random Name</button>
     </form>
   </div>
+  <div id="tradeForm" class="username-prompt hidden">
+    <form>
+      <label for="tradeSymbol">Symbol</label><br/>
+      <input id="tradeSymbol" type="text" autocomplete="off" /><br/>
+      <label for="tradeQty">Quantity</label><br/>
+      <input id="tradeQty" type="number" min="1" /><br/>
+      <button type="button" id="buyBtn">Buy</button>
+      <button type="button" id="sellBtn">Sell</button>
+      <button type="button" id="tradeCloseBtn">Close</button>
+    </form>
+  </div>
   <script src="js/storage.js"></script>
   <script src="js/market.js"></script>
   <script src="js/news.js"></script>
+  <script src="js/player.js"></script>
   <script type="module" src="js/highscores.js"></script>
   <script src="js/game.js"></script>
 </body>

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drawdown - Portfolio</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <h1>Portfolio</h1>
+  <div>Net Worth: $<span id="pNetWorth">0</span></div>
+  <div>Cash: $<span id="pCash">0</span></div>
+  <table id="positionsTable"></table>
+  <div class="analysis-nav">
+    <button type="button" onclick="location.href='play.html'">Back</button>
+  </div>
+  <script src="js/storage.js"></script>
+  <script src="js/player.js"></script>
+  <script src="js/portfolio.js"></script>
+</body>
+</html>

--- a/tests/test_player.js
+++ b/tests/test_player.js
@@ -1,0 +1,33 @@
+const { buyStock, sellStock, computeNetWorth } = require('../docs/js/player.js');
+const assert = require('assert');
+
+function testBuySell() {
+  const state = {
+    cash: 1000,
+    netWorth: 1000,
+    prices: { AAPL: [[100,110,120,130,140]] },
+    positions: {}
+  };
+  const price = 140;
+  assert.ok(buyStock(state, 'AAPL', 5, price));
+  assert.strictEqual(state.cash, 1000 - 5 * price);
+  assert.strictEqual(state.positions['AAPL'].qty, 5);
+  assert.strictEqual(state.positions['AAPL'].cost, 5 * price);
+  computeNetWorth(state);
+  assert.strictEqual(state.netWorth, 1000);
+
+  assert.ok(sellStock(state, 'AAPL', 2, price));
+  assert.strictEqual(state.cash, 1000 - 5 * price + 2 * price);
+  assert.strictEqual(state.positions['AAPL'].qty, 3);
+  computeNetWorth(state);
+  assert.strictEqual(state.netWorth, 1000);
+}
+
+try {
+  testBuySell();
+  console.log('All tests passed');
+} catch (err) {
+  console.error('Test failed');
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add positions tracking to game state
- provide buy/sell helpers and computeNetWorth
- calculate net worth on week advance
- add trade form to play page
- new portfolio screen lists holdings
- tests for trading helpers

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d50b25b308325abea5e213e782dfe