### PR TITLE
Add performance metrics to portfolio page

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -90,6 +90,9 @@ function startGame() {
     saveState(gameState);
   }
   computeNetWorth(gameState);
+  if (!gameState.netWorthHistory) {
+    gameState.netWorthHistory = [gameState.netWorth];
+  }
   displayUsername();
   updateStatus();
   initMarketHistory();
@@ -148,6 +151,9 @@ function nextWeek() {
   const indexWeek = computeIndexWeekPrices(gameState.prices[INDEX_SYMBOL].length);
   gameState.prices[INDEX_SYMBOL].push(indexWeek);
   computeNetWorth(gameState);
+  if (gameState.netWorthHistory) {
+    gameState.netWorthHistory.push(gameState.netWorth);
+  }
   updateRank();
   updateStatus();
   updateMarket();

--- a/docs/js/player.js
+++ b/docs/js/player.js
@@ -5,15 +5,36 @@
 // - Gain to Pain ratio: total return divided by the absolute value of all negative returns
 
 function calculateMaxDrawdown(history) {
-  // TODO: implement max drawdown calculation
+  if (!history || history.length === 0) return 0;
+  let peak = history[0];
+  let maxDD = 0;
+  for (let i = 1; i < history.length; i++) {
+    const value = history[i];
+    if (value > peak) {
+      peak = value;
+    } else {
+      const dd = (peak - value) / peak;
+      if (dd > maxDD) maxDD = dd;
+    }
+  }
+  return +(maxDD * 100).toFixed(2);
 }
 
 function calculateSharpeRatio(returns) {
-  // TODO: implement sharpe ratio calculation
+  if (!returns || returns.length === 0) return 0;
+  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
+  const variance = returns.reduce((a, b) => a + (b - mean) ** 2, 0) / returns.length;
+  const std = Math.sqrt(variance);
+  if (std === 0) return 0;
+  return +(mean / std).toFixed(4);
 }
 
 function calculateGainToPainRatio(returns) {
-  // TODO: implement gain to pain ratio calculation
+  if (!returns || returns.length === 0) return 0;
+  const total = returns.reduce((a, b) => a + b, 0);
+  const pain = returns.filter(r => r < 0).reduce((a, b) => a + Math.abs(b), 0);
+  if (pain === 0) return 0;
+  return +(total / pain).toFixed(4);
 }
 
 function buyStock(state, symbol, qty, price) {
@@ -56,5 +77,12 @@ function computeNetWorth(state) {
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = { buyStock, sellStock, computeNetWorth };
+  module.exports = {
+    buyStock,
+    sellStock,
+    computeNetWorth,
+    calculateMaxDrawdown,
+    calculateSharpeRatio,
+    calculateGainToPainRatio
+  };
 }

--- a/docs/js/portfolio.js
+++ b/docs/js/portfolio.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('pNetWorth').textContent = gameState.netWorth.toLocaleString();
   document.getElementById('pCash').textContent = gameState.cash.toLocaleString();
   renderPositions();
+  renderMetrics();
 });
 
 function renderPositions() {
@@ -27,4 +28,15 @@ function renderPositions() {
     row.innerHTML = `<td>${sym}</td><td>${pos.qty}</td><td>$${parseFloat(value).toLocaleString()}</td>`;
     tbl.appendChild(row);
   });
+}
+
+function renderMetrics() {
+  const hist = gameState.netWorthHistory || [];
+  const rets = [];
+  for (let i = 1; i < hist.length; i++) {
+    rets.push((hist[i] - hist[i - 1]) / hist[i - 1]);
+  }
+  document.getElementById('maxDrawdown').textContent = calculateMaxDrawdown(hist);
+  document.getElementById('sharpeRatio').textContent = calculateSharpeRatio(rets);
+  document.getElementById('gainToPain').textContent = calculateGainToPainRatio(rets);
 }

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -10,6 +10,9 @@
   <h1>Portfolio</h1>
   <div>Net Worth: $<span id="pNetWorth">0</span></div>
   <div>Cash: $<span id="pCash">0</span></div>
+  <div>Max Drawdown: <span id="maxDrawdown">0</span>%</div>
+  <div>Sharpe Ratio: <span id="sharpeRatio">0</span></div>
+  <div>Gain to Pain: <span id="gainToPain">0</span></div>
   <table id="positionsTable"></table>
   <div class="analysis-nav">
     <button type="button" onclick="location.href='play.html'">Back</button>

--- a/tests/test_player.js
+++ b/tests/test_player.js
@@ -1,4 +1,11 @@
-const { buyStock, sellStock, computeNetWorth } = require('../docs/js/player.js');
+const {
+  buyStock,
+  sellStock,
+  computeNetWorth,
+  calculateMaxDrawdown,
+  calculateSharpeRatio,
+  calculateGainToPainRatio
+} = require('../docs/js/player.js');
 const assert = require('assert');
 
 function testBuySell() {
@@ -23,8 +30,23 @@ function testBuySell() {
   assert.strictEqual(state.netWorth, 1000);
 }
 
+function testMetrics() {
+  const history = [100, 110, 105, 120, 118];
+  const returns = [];
+  for (let i = 1; i < history.length; i++) {
+    returns.push((history[i] - history[i - 1]) / history[i - 1]);
+  }
+  const dd = calculateMaxDrawdown(history);
+  const sr = calculateSharpeRatio(returns);
+  const gp = calculateGainToPainRatio(returns);
+  assert.ok(Math.abs(dd - 4.55) < 0.01);
+  assert.ok(sr > 0.57 && sr < 0.58);
+  assert.ok(gp > 2.9 && gp < 2.92);
+}
+
 try {
   testBuySell();
+  testMetrics();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed');


### PR DESCRIPTION
## Summary
- track player net worth history
- implement max drawdown, Sharpe ratio and gain to pain calculations
- show these metrics in the portfolio page
- export new functions for tests
- test metric calculations

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d56afcb788325b2ea5cec65ec35e2