### PR TITLE
Move trade popup to dedicated page

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -199,86 +199,10 @@ function populateTradeSymbols() {
   });
 }
 
-function updateTradeInfo() {
-  const sym = document.getElementById('tradeSymbol').value;
-  const weeks = gameState.prices[sym];
-  if (!weeks) return;
-  const week = weeks[weeks.length - 1];
-  const price = week[week.length - 1];
-  document.getElementById('tradePrice').textContent = price.toFixed(2);
-
-  const slider = document.getElementById('tradeQtySlider');
-  const input = document.getElementById('tradeQty');
-  const maxBuy = Math.floor(gameState.cash / price);
-  const holdings = (gameState.positions[sym] && gameState.positions[sym].qty) || 0;
-  const max = Math.max(maxBuy, holdings, 1);
-  slider.max = max;
-  slider.value = 1;
-  input.value = 1;
-}
-
 function openTrade() {
-  populateTradeSymbols();
-  updateTradeInfo();
-  document.getElementById('tradeForm').classList.remove('hidden');
-}
-
-function closeTrade() {
-  document.getElementById('tradeForm').classList.add('hidden');
-}
-
-function doBuy() {
-  const sym = document.getElementById('tradeSymbol').value.trim().toUpperCase();
-  const qty = parseInt(document.getElementById('tradeQty').value, 10);
-  if (!sym || !qty) return;
-  const weeks = gameState.prices[sym];
-  if (!weeks) {
-    alert('Unknown symbol');
-    return;
-  }
-  const week = weeks[weeks.length - 1];
-  const price = week[week.length - 1];
-  if (!buyStock(gameState, sym, qty, price)) {
-    alert('Not enough cash');
-  } else {
-    updateRank();
-    updateStatus();
-    updateTradeInfo();
-    saveState(gameState);
-  }
-}
-
-function doSell() {
-  const sym = document.getElementById('tradeSymbol').value.trim().toUpperCase();
-  const qty = parseInt(document.getElementById('tradeQty').value, 10);
-  if (!sym || !qty) return;
-  const weeks = gameState.prices[sym];
-  if (!weeks) {
-    alert('Unknown symbol');
-    return;
-  }
-  const week = weeks[weeks.length - 1];
-  const price = week[week.length - 1];
-  if (!sellStock(gameState, sym, qty, price)) {
-    alert('Not enough shares');
-  } else {
-    updateRank();
-    updateStatus();
-    updateTradeInfo();
-    saveState(gameState);
-  }
+  window.location.href = 'trade.html';
 }
 
 document.getElementById('tradeBtn').addEventListener('click', openTrade);
-document.getElementById('tradeCloseBtn').addEventListener('click', closeTrade);
-document.getElementById('buyBtn').addEventListener('click', doBuy);
-document.getElementById('sellBtn').addEventListener('click', doSell);
 document.getElementById('cashOutBtn').addEventListener('click', cashOut);
-document.getElementById('tradeSymbol').addEventListener('change', updateTradeInfo);
-document.getElementById('tradeQtySlider').addEventListener('input', e => {
-  document.getElementById('tradeQty').value = e.target.value;
-});
-document.getElementById('tradeQty').addEventListener('input', e => {
-  document.getElementById('tradeQtySlider').value = e.target.value;
-});
 

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -1,0 +1,106 @@
+let companies = [];
+let gameState;
+
+function populateTradeSymbols() {
+  const select = document.getElementById('tradeSymbol');
+  if (!select) return;
+  if (select.childElementCount > 0) return; // already populated
+  companies.filter(c => !c.isIndex).forEach(c => {
+    const opt = document.createElement('option');
+    opt.value = c.symbol;
+    opt.textContent = `${c.symbol} - ${c.name}`;
+    select.appendChild(opt);
+  });
+}
+
+function updateTradeInfo() {
+  const sym = document.getElementById('tradeSymbol').value;
+  const weeks = gameState.prices[sym];
+  if (!weeks) return;
+  const week = weeks[weeks.length - 1];
+  const price = week[week.length - 1];
+  document.getElementById('tradePrice').textContent = price.toFixed(2);
+
+  const slider = document.getElementById('tradeQtySlider');
+  const input = document.getElementById('tradeQty');
+  const maxBuy = Math.floor(gameState.cash / price);
+  const holdings = (gameState.positions[sym] && gameState.positions[sym].qty) || 0;
+  const max = Math.max(maxBuy, holdings, 1);
+  slider.max = max;
+  slider.value = 1;
+  input.value = 1;
+}
+
+function updateRank() {
+  const worth = gameState.netWorth;
+  if (worth > 1000000) {
+    gameState.rank = 'Tycoon';
+  } else if (worth > 250000) {
+    gameState.rank = 'Trader';
+  } else if (worth > 100000) {
+    gameState.rank = 'Apprentice';
+  } else {
+    gameState.rank = 'Novice';
+  }
+}
+
+function doBuy() {
+  const sym = document.getElementById('tradeSymbol').value.trim().toUpperCase();
+  const qty = parseInt(document.getElementById('tradeQty').value, 10);
+  if (!sym || !qty) return;
+  const weeks = gameState.prices[sym];
+  if (!weeks) {
+    alert('Unknown symbol');
+    return;
+  }
+  const week = weeks[weeks.length - 1];
+  const price = week[week.length - 1];
+  if (!buyStock(gameState, sym, qty, price)) {
+    alert('Not enough cash');
+  } else {
+    updateRank();
+    saveState(gameState);
+    updateTradeInfo();
+  }
+}
+
+function doSell() {
+  const sym = document.getElementById('tradeSymbol').value.trim().toUpperCase();
+  const qty = parseInt(document.getElementById('tradeQty').value, 10);
+  if (!sym || !qty) return;
+  const weeks = gameState.prices[sym];
+  if (!weeks) {
+    alert('Unknown symbol');
+    return;
+  }
+  const week = weeks[weeks.length - 1];
+  const price = week[week.length - 1];
+  if (!sellStock(gameState, sym, qty, price)) {
+    alert('Not enough shares');
+  } else {
+    updateRank();
+    saveState(gameState);
+    updateTradeInfo();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  gameState = loadState();
+  fetch('data/company_master_data.json')
+    .then(r => r.json())
+    .then(data => {
+      companies = data.companies;
+      populateTradeSymbols();
+      updateTradeInfo();
+    });
+
+  document.getElementById('tradeSymbol').addEventListener('change', updateTradeInfo);
+  document.getElementById('tradeQtySlider').addEventListener('input', e => {
+    document.getElementById('tradeQty').value = e.target.value;
+  });
+  document.getElementById('tradeQty').addEventListener('input', e => {
+    document.getElementById('tradeQtySlider').value = e.target.value;
+  });
+  document.getElementById('buyBtn').addEventListener('click', doBuy);
+  document.getElementById('sellBtn').addEventListener('click', doSell);
+});

--- a/docs/play.html
+++ b/docs/play.html
@@ -20,7 +20,7 @@
   <div class="menu">
     <button id="dataBtn">Analysis</button>
     <button id="portfolioBtn">Portfolio</button>
-    <button id="tradeBtn">Trade</button>
+    <button id="tradeBtn" onclick="location.href='trade.html'">Trade</button>
     <button id="doneBtn" class="advance">Advance to Next Week</button>
     <button id="cashOutBtn">Cash Out</button>
   </div>
@@ -39,19 +39,6 @@
       <input id="scoreInput" type="text" autocomplete="off" /><br/>
       <button type="button" id="scoreSubmit">Save</button>
       <button type="button" id="scoreRandom">Random Name</button>
-    </form>
-  </div>
-  <div id="tradeForm" class="username-prompt hidden">
-    <form>
-      <label for="tradeSymbol">Symbol</label><br/>
-      <select id="tradeSymbol"></select><br/>
-      <div>Price: $<span id="tradePrice">0.00</span></div>
-      <label for="tradeQty">Quantity</label><br/>
-      <input id="tradeQty" type="number" min="1" value="1" /><br/>
-      <input id="tradeQtySlider" type="range" min="1" value="1" /><br/>
-      <button type="button" id="buyBtn">Buy</button>
-      <button type="button" id="sellBtn">Sell</button>
-      <button type="button" id="tradeCloseBtn">Close</button>
     </form>
   </div>
   <script src="js/storage.js"></script>

--- a/docs/trade.html
+++ b/docs/trade.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drawdown - Trade</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <h1>Trade</h1>
+  <div id="tradeForm">
+    <label for="tradeSymbol">Symbol</label><br/>
+    <select id="tradeSymbol"></select><br/>
+    <div>Price: $<span id="tradePrice">0.00</span></div>
+    <label for="tradeQty">Quantity</label><br/>
+    <input id="tradeQty" type="number" min="1" value="1" /><br/>
+    <input id="tradeQtySlider" type="range" min="1" value="1" /><br/>
+    <button type="button" id="buyBtn">Buy</button>
+    <button type="button" id="sellBtn">Sell</button>
+  </div>
+  <div class="analysis-nav">
+    <button type="button" onclick="location.href='play.html'">Back</button>
+  </div>
+  <script src="js/storage.js"></script>
+  <script src="js/player.js"></script>
+  <script src="js/trade.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `trade.html` with form and Back button
- add `trade.js` to handle trading interactions
- update `play.html` to link to new page and remove inline form
- simplify `game.js` trade button handler

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d596e52b083258c6a901e90835c7a