### PR TITLE
Add end-of-game page and flow

### DIFF
--- a/docs/analysis.html
+++ b/docs/analysis.html
@@ -25,7 +25,7 @@
   <div class="analysis-nav">
     <button id="prevBtn" type="button">Previous</button>
     <button id="nextBtn" type="button">Next</button>
-    <button id="backBtn" type="button" onclick="location.href='play.html'">Back</button>
+    <button id="backBtn" type="button">Back</button>
   </div>
   <script src="js/storage.js"></script>
   <script src="js/analysis.js"></script>

--- a/docs/game-over.html
+++ b/docs/game-over.html
@@ -20,9 +20,7 @@
   <div class="menu">
     <button id="dataBtn">Analysis</button>
     <button id="portfolioBtn">Portfolio</button>
-    <button id="tradeBtn" onclick="location.href='trade.html'">Trade</button>
-    <button id="doneBtn" class="advance">Advance to Next Week</button>
-    <button id="cashOutBtn">Retire</button>
+    <button id="newGameBtn">Start New Game</button>
   </div>
   <div id="username" class="username"></div>
   <div id="usernamePrompt" class="username-prompt hidden">
@@ -48,7 +46,7 @@
   <script type="module" src="js/highscores.js"></script>
   <script src="js/game.js"></script>
   <script>
-    sessionStorage.setItem('backTo', 'play.html');
+    sessionStorage.setItem('backTo', 'game-over.html');
   </script>
 </body>
 </html>

--- a/docs/js/analysis.js
+++ b/docs/js/analysis.js
@@ -165,4 +165,11 @@ function drawChart(history) {
   ctx.fillText('Week', paddingLeft + chartWidth / 2, canvas.height - 10);
 }
 
-document.addEventListener('DOMContentLoaded', init);
+document.addEventListener('DOMContentLoaded', () => {
+  init();
+  const back = document.getElementById('backBtn');
+  if (back) back.addEventListener('click', () => {
+    const dest = sessionStorage.getItem('backTo') || 'play.html';
+    window.location.href = dest;
+  });
+});

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -129,14 +129,27 @@ function updateRank() {
   }
 }
 
+function endGame() {
+  const afterScore = () => {
+    const admire = confirm('Game over.\nClick OK to admire your work or Cancel to start a new game.');
+    if (admire) {
+      window.location.href = 'game-over.html';
+    } else {
+      sessionStorage.removeItem('backTo');
+      localStorage.clear();
+      window.location.href = 'play.html';
+    }
+  };
+  if (window.drawdownHighScores) {
+    window.drawdownHighScores.check(gameState.netWorth, afterScore);
+  } else {
+    afterScore();
+  }
+}
+
 function nextWeek() {
   if (gameState.week >= gameState.maxWeeks) {
-    alert('Game over');
-    if (window.drawdownHighScores) {
-      window.drawdownHighScores.check(gameState.netWorth, () => {
-        window.location.href = 'high-scores.html';
-      });
-    }
+    endGame();
     return;
   }
   gameState.week += 1;
@@ -162,28 +175,24 @@ function nextWeek() {
 }
 
 function cashOut() {
-  alert('Game over');
-  if (window.drawdownHighScores) {
-    window.drawdownHighScores.check(gameState.netWorth, () => {
-      window.location.href = 'high-scores.html';
-    });
-  } else {
-    window.location.href = 'high-scores.html';
-  }
+  endGame();
 }
 
 function showPlaceholder(msg) {
   alert(msg + ' screen goes here.');
 }
 
-document.getElementById('doneBtn').addEventListener('click', nextWeek);
-document.getElementById('dataBtn').addEventListener('click', () => {
+const doneEl = document.getElementById('doneBtn');
+if (doneEl) doneEl.addEventListener('click', nextWeek);
+const dataEl = document.getElementById('dataBtn');
+if (dataEl) dataEl.addEventListener('click', () => {
   window.location.href = 'analysis.html';
 });
 // TODO: replace placeholder with a full portfolio screen showing
 // open positions and trading performance metrics like max drawdown,
 // sharpe ratio, and gain to pain ratio.
-document.getElementById('portfolioBtn').addEventListener('click', () => {
+const portEl = document.getElementById('portfolioBtn');
+if (portEl) portEl.addEventListener('click', () => {
   window.location.href = 'portfolio.html';
 });
 
@@ -203,6 +212,14 @@ function openTrade() {
   window.location.href = 'trade.html';
 }
 
-document.getElementById('tradeBtn').addEventListener('click', openTrade);
-document.getElementById('cashOutBtn').addEventListener('click', cashOut);
+const tradeEl = document.getElementById('tradeBtn');
+if (tradeEl) tradeEl.addEventListener('click', openTrade);
+const cashEl = document.getElementById('cashOutBtn');
+if (cashEl) cashEl.addEventListener('click', cashOut);
+const newGameEl = document.getElementById('newGameBtn');
+if (newGameEl) newGameEl.addEventListener('click', () => {
+  sessionStorage.removeItem('backTo');
+  localStorage.clear();
+  window.location.href = 'play.html';
+});
 

--- a/docs/js/portfolio.js
+++ b/docs/js/portfolio.js
@@ -9,6 +9,11 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('pCash').textContent = gameState.cash.toLocaleString();
   renderPositions();
   renderMetrics();
+  const back = document.getElementById('backBtn');
+  if (back) back.addEventListener('click', () => {
+    const dest = sessionStorage.getItem('backTo') || 'play.html';
+    window.location.href = dest;
+  });
 });
 
 function renderPositions() {

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -15,7 +15,7 @@
   <div>Gain to Pain: <span id="gainToPain">0</span></div>
   <table id="positionsTable"></table>
   <div class="analysis-nav">
-    <button type="button" onclick="location.href='play.html'">Back</button>
+    <button id="backBtn" type="button">Back</button>
   </div>
   <script src="js/storage.js"></script>
   <script src="js/player.js"></script>


### PR DESCRIPTION
## Summary
- create `game-over.html` to view final charts
- offer to admire results or start a new game when game ends
- ensure missing buttons are handled in `game.js`
- adjust analysis/portfolio back buttons based on session storage
- mark navigation source on play pages

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d5dda247c832592407760140705ed