### PR TITLE
Increase bearish bias

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -8,6 +8,12 @@ fetch('data/company_master_data.json')
   .then(r => r.json())
   .then(data => {
     companies = data.companies;
+    // make stocks trend downward by flipping the sign of the drift term
+    companies.forEach(c => {
+      if (typeof c.mu === 'number') {
+        c.mu = -Math.abs(c.mu);
+      }
+    });
     setupMarketIndex();
     ensureUser(() => {
       startGame();


### PR DESCRIPTION
## Summary
- make equities drift downward by inverting the per-company `mu` value

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d5f71eb948325a481db1a2786ffe8