### PR TITLE
Improve analysis page layout

### DIFF
--- a/docs/analysis.html
+++ b/docs/analysis.html
@@ -7,25 +7,27 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1>Company Analysis</h1>
-  <div>
-    <label for="companySelect">Select Company:</label>
-    <select id="companySelect"></select>
-  </div>
-  <div id="metrics">
-    <div>Price: $<span id="price">0</span></div>
-    <div>Volatility: <span id="volatility">0</span></div>
-    <div>Average: $<span id="average">0</span></div>
-    <div>High: $<span id="high">0</span></div>
-    <div>Low: $<span id="low">0</span></div>
-  </div>
-  <div class="chart-wrapper">
-    <canvas id="companyChart" width="600" height="350"></canvas>
-  </div>
-  <div class="analysis-nav">
-    <button id="prevBtn" type="button">Previous</button>
-    <button id="nextBtn" type="button">Next</button>
-    <button id="backBtn" type="button">Back</button>
+  <div class="analysis-container">
+    <h1>Company Analysis</h1>
+    <div class="company-select">
+      <label for="companySelect">Select Company:</label>
+      <select id="companySelect"></select>
+    </div>
+    <div id="metrics">
+      <div>Price: $<span id="price">0</span></div>
+      <div>Volatility: <span id="volatility">0</span></div>
+      <div>Average: $<span id="average">0</span></div>
+      <div>High: $<span id="high">0</span></div>
+      <div>Low: $<span id="low">0</span></div>
+    </div>
+    <div class="chart-wrapper">
+      <canvas id="companyChart" width="600" height="350"></canvas>
+    </div>
+    <div class="analysis-nav">
+      <button id="nextBtn" type="button">Next Company</button>
+      <button id="prevBtn" type="button">Previous Company</button>
+      <button id="backBtn" type="button">Back to Overview</button>
+    </div>
   </div>
   <script src="js/storage.js"></script>
   <script src="js/analysis.js"></script>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -153,9 +153,28 @@ button:hover {
   display: none;
 }
 
+.analysis-container {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.company-select {
+  margin-bottom: 1rem;
+}
+
+select {
+  background: #000;
+  color: #33ff33;
+  border: 1px solid #33ff33;
+  padding: 0.5rem;
+}
+
 .analysis-nav {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
   max-width: 600px;
   margin: 1rem auto;
 }


### PR DESCRIPTION
## Summary
- center the analysis page elements
- apply retro style to company selector
- arrange nav buttons vertically with clearer labels

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d60cbfb288325860cc27f6749613a