### PR TITLE
Improve portfolio page styling

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -182,3 +182,25 @@ select {
 #tradeQtySlider {
   width: 100%;
 }
+
+.portfolio-container {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.metrics-table,
+#positionsTable {
+  margin: 1rem auto;
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 400px;
+}
+
+.metrics-table th,
+.metrics-table td,
+#positionsTable th,
+#positionsTable td {
+  border: 1px solid #33ff33;
+  padding: 0.5rem;
+}

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -7,15 +7,19 @@
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
-  <h1>Portfolio</h1>
-  <div>Net Worth: $<span id="pNetWorth">0</span></div>
-  <div>Cash: $<span id="pCash">0</span></div>
-  <div>Max Drawdown: <span id="maxDrawdown">0</span>%</div>
-  <div>Sharpe Ratio: <span id="sharpeRatio">0</span></div>
-  <div>Gain to Pain: <span id="gainToPain">0</span></div>
-  <table id="positionsTable"></table>
-  <div class="analysis-nav">
-    <button id="backBtn" type="button">Back</button>
+  <div class="portfolio-container">
+    <h1>Portfolio</h1>
+    <table class="metrics-table">
+      <tr><th>Net Worth</th><td>$<span id="pNetWorth">0</span></td></tr>
+      <tr><th>Cash</th><td>$<span id="pCash">0</span></td></tr>
+      <tr><th>Max Drawdown</th><td><span id="maxDrawdown">0</span>%</td></tr>
+      <tr><th>Sharpe Ratio</th><td><span id="sharpeRatio">0</span></td></tr>
+      <tr><th>Gain to Pain</th><td><span id="gainToPain">0</span></td></tr>
+    </table>
+    <table id="positionsTable"></table>
+    <div class="analysis-nav">
+      <button id="backBtn" type="button">Back to Overview</button>
+    </div>
   </div>
   <script src="js/storage.js"></script>
   <script src="js/player.js"></script>


### PR DESCRIPTION
## Summary
- use tables on portfolio page with consistent green border styling
- center portfolio content and add space between elements
- change back button text to match analysis page

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d6302d10483259b15e70d054865bf