### PR TITLE
Enhance trade page with metrics and history

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -179,8 +179,37 @@ select {
   margin: 1rem auto;
 }
 
+.trade-container {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+#tradeForm {
+  margin-bottom: 1rem;
+}
+
+#tradeHistoryTable {
+  margin: 1rem auto;
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 400px;
+}
+
+#tradeHistoryTable th,
+#tradeHistoryTable td {
+  border: 1px solid #33ff33;
+  padding: 0.5rem;
+}
+
+.confirm-message {
+  margin: 0.5rem auto;
+  color: #66ff66;
+}
+
 #tradeQtySlider {
   width: 100%;
+  accent-color: #33ff33;
 }
 
 .portfolio-container {

--- a/docs/trade.html
+++ b/docs/trade.html
@@ -7,19 +7,27 @@
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
-  <h1>Trade</h1>
-  <div id="tradeForm">
-    <label for="tradeSymbol">Symbol</label><br/>
-    <select id="tradeSymbol"></select><br/>
-    <div>Price: $<span id="tradePrice">0.00</span></div>
-    <label for="tradeQty">Quantity</label><br/>
-    <input id="tradeQty" type="number" min="1" value="1" /><br/>
-    <input id="tradeQtySlider" type="range" min="1" value="1" /><br/>
-    <button type="button" id="buyBtn">Buy</button>
-    <button type="button" id="sellBtn">Sell</button>
-  </div>
-  <div class="analysis-nav">
-    <button type="button" onclick="location.href='play.html'">Back</button>
+  <div class="trade-container">
+    <h1>Trade</h1>
+    <table class="metrics-table">
+      <tr><th>Net Worth</th><td>$<span id="tNetWorth">0</span></td></tr>
+      <tr><th>Cash</th><td>$<span id="tCash">0</span></td></tr>
+    </table>
+    <div id="tradeForm">
+      <label for="tradeSymbol">Symbol</label><br/>
+      <select id="tradeSymbol"></select><br/>
+      <div>Price: $<span id="tradePrice">0.00</span></div>
+      <label for="tradeQty">Quantity</label><br/>
+      <input id="tradeQty" type="number" min="1" value="1" /><br/>
+      <input id="tradeQtySlider" type="range" min="1" value="1" /><br/>
+      <button type="button" id="buyBtn">Buy</button>
+      <button type="button" id="sellBtn">Sell</button>
+    </div>
+    <div id="tradeConfirm" class="confirm-message"></div>
+    <table id="tradeHistoryTable"></table>
+    <div class="analysis-nav">
+      <button type="button" onclick="location.href='play.html'">Back</button>
+    </div>
   </div>
   <script src="js/storage.js"></script>
   <script src="js/player.js"></script>


### PR DESCRIPTION
## Summary
- revamp the Trade page layout
- add trade confirmation message and history table
- show net worth and cash
- tweak green styling, including slider accent

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d6679f75c8325a75dff66ec524164