### PR TITLE
Maintain play page layout and confirm cash out

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -107,7 +107,8 @@ button:hover {
 .news {
   margin: 1rem auto;
   max-width: 600px;
-  min-height: 4.5rem;
+  /* Reserve space for up to four headlines so the menu doesn't shift */
+  min-height: 8rem;
 }
 
 .news .headline {

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -178,7 +178,10 @@ function nextWeek() {
 }
 
 function cashOut() {
-  endGame();
+  const confirmMsg = 'Are you sure you want to retire and cash out?';
+  if (confirm(confirmMsg)) {
+    endGame();
+  }
 }
 
 function showPlaceholder(msg) {


### PR DESCRIPTION
## Summary
- ensure the news section on the play page reserves room for four headlines so the buttons stay in a consistent spot
- ask for confirmation before retiring from a game

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d6814e3808325a9e16906968b388a