### PR TITLE
Add retro-styled game over dialog

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -153,16 +153,48 @@ function updateRank() {
   }
 }
 
+function showGameOverDialog() {
+  const dialogEl = document.getElementById('gameOverDialog');
+  if (!dialogEl) return;
+  const admireBtn = document.getElementById('gameOverAdmire');
+  const newBtn = document.getElementById('gameOverNew');
+  const menuBtn = document.getElementById('gameOverMenu');
+
+  function cleanup() {
+    admireBtn.removeEventListener('click', onAdmire);
+    newBtn.removeEventListener('click', onNew);
+    menuBtn.removeEventListener('click', onMenu);
+    dialogEl.classList.add('hidden');
+  }
+
+  function onAdmire() {
+    cleanup();
+    window.location.href = 'game-over.html';
+  }
+
+  function onNew() {
+    cleanup();
+    sessionStorage.removeItem('backTo');
+    localStorage.clear();
+    window.location.href = 'play.html';
+  }
+
+  function onMenu() {
+    cleanup();
+    sessionStorage.removeItem('backTo');
+    localStorage.clear();
+    window.location.href = 'index.html';
+  }
+
+  admireBtn.addEventListener('click', onAdmire);
+  newBtn.addEventListener('click', onNew);
+  menuBtn.addEventListener('click', onMenu);
+  dialogEl.classList.remove('hidden');
+}
+
 function endGame() {
   const afterScore = () => {
-    const admire = confirm('Game over.\nClick OK to admire your work or Cancel to start a new game.');
-    if (admire) {
-      window.location.href = 'game-over.html';
-    } else {
-      sessionStorage.removeItem('backTo');
-      localStorage.clear();
-      window.location.href = 'play.html';
-    }
+    showGameOverDialog();
   };
   if (window.drawdownHighScores) {
     window.drawdownHighScores.check(gameState.netWorth, afterScore);

--- a/docs/play.html
+++ b/docs/play.html
@@ -41,6 +41,14 @@
       <button type="button" id="scoreRandom">Random Name</button>
     </form>
   </div>
+  <div id="gameOverDialog" class="username-prompt hidden">
+    <form>
+      <p>Game over.</p>
+      <button type="button" id="gameOverAdmire">View Results</button>
+      <button type="button" id="gameOverNew">Start New Game</button>
+      <button type="button" id="gameOverMenu">Main Menu</button>
+    </form>
+  </div>
   <script src="js/storage.js"></script>
   <script src="js/market.js"></script>
   <script src="js/news.js"></script>


### PR DESCRIPTION
## Summary
- add a monochrome-styled game over overlay in play.html
- provide navigation to results, new game, or main menu
- wire up overlay logic in game.js

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d6f72c9bc83258b0332a6e18a0495