### PR TITLE
Add donation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,10 @@ MIT License. Do what you want, but don’t blame me when your portfolio goes to 
 
 ---
 
+## Support
+
+If Drawdown has entertained you, consider [buying me a coffee](https://coff.ee/stevedrasco). Even a small donation helps keep the caffeine flowing during those inevitable drawdowns.
+
+---
+
 © 2025 Steve Drasco · steve.drasco@gmail.com

--- a/docs/high-scores.html
+++ b/docs/high-scores.html
@@ -30,13 +30,28 @@
     a {
       color: #33ff33;
     }
+    .link-wrapper {
+      font-size: 0.95rem;
+      color: #33ff33;
+      text-decoration: none;
+      border: 1px solid #33ff33;
+      background: #222;
+      padding: 8px 12px;
+      margin: 10px 0;
+      display: block;
+      cursor: pointer;
+    }
+    .link-wrapper:hover {
+      background: #33ff33;
+      color: #000;
+    }
   </style>
 </head>
 <body>
   <h1>High Scores</h1>
   <table id="scoresTable"></table>
   <p><a href="index.html">Back</a></p>
-
+  <a class="link-wrapper" href="https://coff.ee/stevedrasco" target="_blank">Coffee for Drawdowns</a>
   <script type="module">
     import { initScores, loadBoard, watchBoard } from './js/highscores.js';
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -127,6 +127,9 @@
       <a class="link-wrapper" href="https://github.com/sdrasco/drawdowngame/blob/main/README.md" target="_blank">
         About
       </a>
+      <a class="link-wrapper" href="https://coff.ee/stevedrasco" target="_blank">
+        Coffee for Drawdowns
+      </a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- add Buy Me a Coffee links on landing and high scores pages
- mention Buy Me a Coffee support option in README

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685d784466b88325a596d6e301a4929f