### PR TITLE
Enable industry news events

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -80,16 +80,32 @@ function newsImpactsForWeek(week) {
   const impacts = {};
   const headlines = gameState.headlines[week] || [];
   headlines.forEach(h => {
-    if (!h || !h.symbol) return;
-    const sign = h.type === "good" ? 1 : h.type === "bad" ? -1 : 0;
-    if (sign === 0) return;
-    if (!impacts[h.symbol]) impacts[h.symbol] = { drift: 0, jump: 0, vol: false };
-    if (h.impact) {
-      const mag = 0.1 + 0.1 * Math.random();
-      impacts[h.symbol].jump += sign * Math.log(1 + mag);
-      impacts[h.symbol].vol = true;
-    } else {
-      impacts[h.symbol].drift += sign * 0.02;
+    if (!h) return;
+    if (h.symbol) {
+      const sign = h.type === "good" ? 1 : h.type === "bad" ? -1 : 0;
+      if (sign === 0) return;
+      if (!impacts[h.symbol]) impacts[h.symbol] = { drift: 0, jump: 0, vol: false };
+      if (h.impact) {
+        const mag = 0.1 + 0.1 * Math.random();
+        impacts[h.symbol].jump += sign * Math.log(1 + mag);
+        impacts[h.symbol].vol = true;
+      } else {
+        impacts[h.symbol].drift += sign * 0.02;
+      }
+    } else if (h.industry) {
+      const sign = h.sentiment || 0;
+      if (sign === 0) return;
+      const magKey = h.magnitude || 'small';
+      const mag = magKey === 'large' ? 0.15 : magKey === 'medium' ? 0.1 : 0.05;
+      const jump = sign * Math.log(1 + mag);
+      companies.forEach(c => {
+        if (c.isIndex) return;
+        const ind = h.category || h.industry;
+        if (c.industry !== ind) return;
+        if (!impacts[c.symbol]) impacts[c.symbol] = { drift: 0, jump: 0, vol: false };
+        impacts[c.symbol].jump += jump;
+        impacts[c.symbol].vol = true;
+      });
     }
   });
   return impacts;

--- a/docs/js/news.js
+++ b/docs/js/news.js
@@ -6,15 +6,27 @@ function shuffle(arr) {
   }
 }
 
+const INDUSTRY_MAP = {
+  Software: 'Computer / Tech',
+  Semiconductors: 'Computer / Tech',
+  Retail: 'Retail',
+  Energy: 'Oil and Gas',
+  Banking: 'Heavy Industry / Materials'
+};
+
 function generateHeadlines() {
-  const n = Math.floor(Math.random() * 5); // 0-4
-  if (n === 0) {
+  const result = [];
+  if (typeof maybeGenerateIndustryNews === 'function') {
+    maybeGenerateIndustryNews(result);
+  }
+
+  let n = Math.floor(Math.random() * 5); // 0-4 company headlines
+  if (n === 0 && result.length === 0) {
     return [{ text: 'No market headlines this week.' }];
   }
   const available = companies.filter(c => !c.isIndex);
   shuffle(available);
-  const chosen = available.slice(0, n);
-  const result = [];
+  const chosen = available.slice(0, Math.min(n, 4 - result.length));
   chosen.forEach(c => {
     const typeKey = Math.random() < 0.5 ? 'good_news_headlines' : 'bad_news_headlines';
     const pool = c[typeKey] || [];
@@ -28,7 +40,16 @@ function generateHeadlines() {
       });
     }
   });
-  return result;
+
+  // convert industry events to a common format and limit to 4 total
+  result.forEach(evt => {
+    if (evt.industry) {
+      evt.text = evt.headline;
+      evt.category = INDUSTRY_MAP[evt.industry] || evt.industry;
+    }
+  });
+
+  return result.slice(0, 4);
 }
 
 function renderNews() {

--- a/docs/play.html
+++ b/docs/play.html
@@ -51,6 +51,7 @@
   </div>
   <script src="js/storage.js"></script>
   <script src="js/market.js"></script>
+  <script src="js/news_engine.js"></script>
   <script src="js/news.js"></script>
   <script src="js/player.js"></script>
   <script type="module" src="js/highscores.js"></script>


### PR DESCRIPTION
## Summary
- inject `news_engine.js` in the main game page
- generate industry news alongside company headlines
- convert industry headlines to effects in the price simulation

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685e738e70e8832596d5e465c5976522