### PR TITLE
Add Firestore test page and improve score error handling

### DIFF
--- a/docs/js/highscores.js
+++ b/docs/js/highscores.js
@@ -57,7 +57,13 @@ export async function initScores() {
 
 // 5. Submit a new real score
 export async function submitScore(player, score) {
-  await addDoc(scoresRef, { player, score, ts: Date.now() });
+  try {
+    await addDoc(scoresRef, { player, score, ts: Date.now() });
+  } catch (err) {
+    console.error('Failed to save score', err);
+    alert('Saving your score failed. Please try again later.');
+    throw err;
+  }
 }
 
 // 6. Load top-10 once
@@ -135,7 +141,11 @@ export async function check(score, cb) {
   if (needsSave) {
     alert('Congratulations! You made the high score board!');
     const name = await promptForScoreName(window.getUser());
-    await submitScore(name, score);
+    try {
+      await submitScore(name, score);
+    } catch (err) {
+      console.error('submitScore failed', err);
+    }
   }
   if (typeof cb === 'function') cb();
 }

--- a/docs/testfirestore.html
+++ b/docs/testfirestore.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drawdown - Firestore Test</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <h1>Firestore Connectivity Test</h1>
+  <div class="section">
+    <button id="initBtn" type="button">Seed Sample Scores</button>
+    <button id="readBtn" type="button">Load Scores</button>
+  </div>
+  <div class="section">
+    <label for="nameInput">Name:</label>
+    <input id="nameInput" type="text" />
+    <label for="scoreInput">Score:</label>
+    <input id="scoreInput" type="number" />
+    <button id="writeBtn" type="button">Submit Score</button>
+  </div>
+  <pre id="output" class="section"></pre>
+  <p><a href="index.html">Back</a></p>
+  <script type="module">
+    import { initScores, loadBoard, submitScore } from './js/highscores.js';
+
+    const output = document.getElementById('output');
+    const log = (msg) => { output.textContent += msg + '\n'; };
+
+    document.getElementById('initBtn').addEventListener('click', async () => {
+      log('Seeding scores...');
+      try {
+        await initScores();
+        log('Seed complete');
+      } catch (err) {
+        console.error(err);
+        log('Seed failed: ' + err.message);
+      }
+    });
+
+    document.getElementById('readBtn').addEventListener('click', async () => {
+      log('Loading scores...');
+      try {
+        const board = await loadBoard();
+        log(JSON.stringify(board, null, 2));
+      } catch (err) {
+        console.error(err);
+        log('Load failed: ' + err.message);
+      }
+    });
+
+    document.getElementById('writeBtn').addEventListener('click', async () => {
+      const name = document.getElementById('nameInput').value || 'test';
+      const score = Number(document.getElementById('scoreInput').value) || 0;
+      log('Submitting score...');
+      try {
+        await submitScore(name, score);
+        log('Score submitted');
+      } catch (err) {
+        console.error(err);
+        log('Write failed: ' + err.message);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- wrap `addDoc` in `submitScore()` with try/catch
- keep callback execution in `check()` even when submitting fails
- create `testfirestore.html` page to test Firestore connectivity

## Testing
- `node tests/test_player.js`


------
https://chatgpt.com/codex/tasks/task_e_685e7c4e632083258ff3e77cd9fd4069