### PR TITLE
Fix high scores donation button width

### DIFF
--- a/docs/high-scores.html
+++ b/docs/high-scores.html
@@ -37,7 +37,9 @@
       border: 1px solid #33ff33;
       background: #222;
       padding: 8px 12px;
-      margin: 10px 0;
+      margin: 10px auto;
+      width: 100%;
+      max-width: 400px;
       display: block;
       cursor: pointer;
     }


### PR DESCRIPTION
## Summary
- resize donation button on the high scores page to fit the table width

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685eaa073b2c8325b2ac96ac233f56ed