### PR TITLE
Fix high score check initialization

### DIFF
--- a/docs/firestore-diagnostics.html
+++ b/docs/firestore-diagnostics.html
@@ -38,6 +38,7 @@
   </div>
   <pre id="output" class="section"></pre>
   <p><a href="index.html">Back</a></p>
+  <script src="js/storage.js"></script>
   <script type="module">
     import { initScores, loadBoard, watchBoard, check } from './js/highscores.js';
 

--- a/docs/js/highscores.js
+++ b/docs/js/highscores.js
@@ -140,7 +140,11 @@ export async function check(score, cb) {
     (board.length && score > board[board.length - 1].score);
   if (needsSave) {
     alert('Congratulations! You made the high score board!');
-    const name = await promptForScoreName(window.getUser());
+    const defaultName =
+      (typeof window !== 'undefined' && typeof window.getUser === 'function')
+        ? window.getUser()
+        : '';
+    const name = await promptForScoreName(defaultName);
     try {
       await submitScore(name, score);
     } catch (err) {


### PR DESCRIPTION
## Summary
- load storage.js in Firestore diagnostics page
- guard against missing `getUser` when running a high score check

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685eb7ddb97c8325a709d1da36cd119e