### PR TITLE
Improve end-game flow

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -250,3 +250,8 @@ select {
   border: 1px solid #33ff33;
   padding: 0.5rem;
 }
+
+.final-worth {
+  font-weight: bold;
+  color: #66ff66;
+}

--- a/docs/game-over.html
+++ b/docs/game-over.html
@@ -9,7 +9,7 @@
 <body>
   <div id="status" class="status">
     <div>Week: <span id="week">14</span>/<span id="maxWeek">104</span></div>
-    <div>Net Worth: $<span id="netWorth">35000</span></div>
+    <div>Net Worth: $<span id="netWorth" class="final-worth">35000</span></div>
     <div>Rank: <span id="rank">Novice</span></div>
     <div>Cash: $<span id="cash">35000</span></div>
   </div>
@@ -20,7 +20,9 @@
   <div class="menu">
     <button id="dataBtn">Analysis</button>
     <button id="portfolioBtn">Portfolio</button>
+    <button id="scoresBtn">High Scores</button>
     <button id="newGameBtn">Start New Game</button>
+    <button id="menuBtn">Main Menu</button>
   </div>
   <div id="username" class="username"></div>
   <div id="usernamePrompt" class="username-prompt hidden">

--- a/docs/js/analysis.js
+++ b/docs/js/analysis.js
@@ -9,6 +9,10 @@ function init() {
       companies = data.companies.filter(c => !c.isIndex);
       populateSelect();
       gameState = loadState();
+      if (gameState && (gameState.week >= gameState.maxWeeks || gameState.gameOver)) {
+        window.location.href = 'game-over.html';
+        return;
+      }
       const sel = document.getElementById('companySelect');
       sel.addEventListener('change', () => {
         currentIndex = companies.findIndex(c => c.symbol === sel.value);

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -119,6 +119,9 @@ function startGame() {
   if (gameState && !gameState.newsDrift) {
     gameState.newsDrift = {};
   }
+  if (gameState && gameState.gameOver === undefined) {
+    gameState.gameOver = false;
+  }
   if (!gameState) {
     gameState = {
       week: START_WEEK,
@@ -129,7 +132,8 @@ function startGame() {
       rank: 'Novice',
       headlines: {},
       prices: {},
-      newsDrift: {}
+      newsDrift: {},
+      gameOver: false
     };
     const lastPrices = {};
     companies.forEach(c => {
@@ -162,6 +166,16 @@ function startGame() {
   initMarketHistory();
   renderMarketChart();
   renderNews();
+  if (gameState.week >= gameState.maxWeeks || gameState.gameOver) {
+    gameState.gameOver = true;
+    const done = document.getElementById('doneBtn');
+    if (done) {
+      done.disabled = true;
+      done.classList.add('hidden');
+    }
+    saveState(gameState);
+    showGameOverDialog();
+  }
 }
 
 function updateStatus() {
@@ -197,11 +211,15 @@ function showGameOverDialog() {
   const dialogEl = document.getElementById('gameOverDialog');
   if (!dialogEl) return;
   const admireBtn = document.getElementById('gameOverAdmire');
+  const scoresBtn = document.getElementById('gameOverScores');
   const newBtn = document.getElementById('gameOverNew');
   const menuBtn = document.getElementById('gameOverMenu');
+  const worthEl = document.getElementById('gameOverNetWorth');
+  if (worthEl) worthEl.textContent = gameState.netWorth.toLocaleString();
 
   function cleanup() {
     admireBtn.removeEventListener('click', onAdmire);
+    scoresBtn.removeEventListener('click', onScores);
     newBtn.removeEventListener('click', onNew);
     menuBtn.removeEventListener('click', onMenu);
     dialogEl.classList.add('hidden');
@@ -210,6 +228,11 @@ function showGameOverDialog() {
   function onAdmire() {
     cleanup();
     window.location.href = 'game-over.html';
+  }
+
+  function onScores() {
+    cleanup();
+    window.location.href = 'high-scores.html';
   }
 
   function onNew() {
@@ -227,6 +250,7 @@ function showGameOverDialog() {
   }
 
   admireBtn.addEventListener('click', onAdmire);
+  scoresBtn.addEventListener('click', onScores);
   newBtn.addEventListener('click', onNew);
   menuBtn.addEventListener('click', onMenu);
   dialogEl.classList.remove('hidden');
@@ -236,6 +260,13 @@ function endGame() {
   const afterScore = () => {
     showGameOverDialog();
   };
+  gameState.gameOver = true;
+  const done = document.getElementById('doneBtn');
+  if (done) {
+    done.disabled = true;
+    done.classList.add('hidden');
+  }
+  saveState(gameState);
   if (window.drawdownHighScores) {
     window.drawdownHighScores.check(gameState.netWorth, afterScore);
   } else {
@@ -327,5 +358,17 @@ if (newGameEl) newGameEl.addEventListener('click', () => {
   sessionStorage.removeItem('backTo');
   localStorage.clear();
   window.location.href = 'play.html';
+});
+
+const menuBtnEl = document.getElementById('menuBtn');
+if (menuBtnEl) menuBtnEl.addEventListener('click', () => {
+  sessionStorage.removeItem('backTo');
+  localStorage.clear();
+  window.location.href = 'index.html';
+});
+
+const scoresBtnEl = document.getElementById('scoresBtn');
+if (scoresBtnEl) scoresBtnEl.addEventListener('click', () => {
+  window.location.href = 'high-scores.html';
 });
 

--- a/docs/js/portfolio.js
+++ b/docs/js/portfolio.js
@@ -2,6 +2,10 @@ let gameState;
 
 document.addEventListener('DOMContentLoaded', () => {
   gameState = loadState();
+  if (gameState && (gameState.week >= gameState.maxWeeks || gameState.gameOver)) {
+    window.location.href = 'game-over.html';
+    return;
+  }
   if (!gameState) return;
   if (!gameState.positions) gameState.positions = {};
   computeNetWorth(gameState);

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -122,6 +122,10 @@ function doSell() {
 
 document.addEventListener('DOMContentLoaded', () => {
   gameState = loadState();
+  if (gameState && (gameState.week >= gameState.maxWeeks || gameState.gameOver)) {
+    window.location.href = 'game-over.html';
+    return;
+  }
   renderMetrics();
   renderTradeHistory();
   fetch('data/company_master_data.json')

--- a/docs/play.html
+++ b/docs/play.html
@@ -44,7 +44,9 @@
   <div id="gameOverDialog" class="username-prompt hidden">
     <form>
       <p>Game over.</p>
+      <p class="final-worth">Final Net Worth: $<span id="gameOverNetWorth"></span></p>
       <button type="button" id="gameOverAdmire">View Results</button>
+      <button type="button" id="gameOverScores">High Scores</button>
       <button type="button" id="gameOverNew">Start New Game</button>
       <button type="button" id="gameOverMenu">Main Menu</button>
     </form>


### PR DESCRIPTION
## Summary
- highlight final wealth in game over dialog
- link to high scores and main menu when the game ends
- disable advancing when the game is over and persist a `gameOver` flag
- redirect analysis, trade and portfolio pages if the game ended

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685f84bdef888325aa5091832af03109