### PR TITLE
Fix admire view for analysis/portfolio

### DIFF
--- a/docs/js/analysis.js
+++ b/docs/js/analysis.js
@@ -9,7 +9,8 @@ function init() {
       companies = data.companies.filter(c => !c.isIndex);
       populateSelect();
       gameState = loadState();
-      if (gameState && (gameState.week >= gameState.maxWeeks || gameState.gameOver)) {
+      const backTo = sessionStorage.getItem('backTo');
+      if (gameState && (gameState.week >= gameState.maxWeeks || gameState.gameOver) && backTo !== 'game-over.html') {
         window.location.href = 'game-over.html';
         return;
       }

--- a/docs/js/portfolio.js
+++ b/docs/js/portfolio.js
@@ -2,7 +2,8 @@ let gameState;
 
 document.addEventListener('DOMContentLoaded', () => {
   gameState = loadState();
-  if (gameState && (gameState.week >= gameState.maxWeeks || gameState.gameOver)) {
+  const backTo = sessionStorage.getItem('backTo');
+  if (gameState && (gameState.week >= gameState.maxWeeks || gameState.gameOver) && backTo !== 'game-over.html') {
     window.location.href = 'game-over.html';
     return;
   }


### PR DESCRIPTION
## Summary
- let players access analysis/portfolio after finishing a game
- detect when a user is coming from the admire screen so they aren't redirected

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f8ef5ec1083259f0f88bb370872f0