### PR TITLE
Fix headlines size on mobile play page

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -82,7 +82,7 @@ button:hover {
     font-size: 1.2rem;
   }
   .news {
-    font-size: 1.2rem;
+    font-size: 0.8rem;
   }
 
   /* Keep the status header small to avoid clutter */


### PR DESCRIPTION
## Summary
- tweak the mobile CSS rules so headlines match status text size

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_685fe2767d6883258d7a857c682bd95d