### PR TITLE
Add live transaction total on trade page

### DIFF
--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -1,5 +1,6 @@
 let companies = [];
 let gameState;
+let tradeMode = 'BUY';
 
 function renderMetrics() {
   if (!gameState) return;
@@ -60,6 +61,26 @@ function updateTradeInfo() {
   slider.max = max;
   slider.value = 1;
   input.value = 1;
+  updateTradeTotal();
+}
+
+function updateTradeTotal() {
+  const qty = parseInt(document.getElementById('tradeQty').value, 10) || 0;
+  const price = parseFloat(document.getElementById('tradePrice').textContent) || 0;
+  const tradeValue = qty * price;
+  const commission = TRADE_COMMISSION;
+  const fees = +(tradeValue * TRADE_FEE_RATE).toFixed(2);
+  let total;
+  const label = document.getElementById('tradeTotalLabel');
+  if (tradeMode === 'SELL') {
+    total = tradeValue - commission - fees;
+    if (label) label.textContent = 'Net Proceeds:';
+  } else {
+    total = tradeValue + commission + fees;
+    if (label) label.textContent = 'Total Cost:';
+  }
+  const span = document.getElementById('tradeTotal');
+  if (span) span.textContent = total.toFixed(2);
 }
 
 function updateRank() {
@@ -158,10 +179,16 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('tradeSymbol').addEventListener('change', updateTradeInfo);
   document.getElementById('tradeQtySlider').addEventListener('input', e => {
     document.getElementById('tradeQty').value = e.target.value;
+    updateTradeTotal();
   });
   document.getElementById('tradeQty').addEventListener('input', e => {
     document.getElementById('tradeQtySlider').value = e.target.value;
+    updateTradeTotal();
   });
   document.getElementById('buyBtn').addEventListener('click', doBuy);
   document.getElementById('sellBtn').addEventListener('click', doSell);
+  document.getElementById('buyBtn').addEventListener('mouseenter', () => { tradeMode = 'BUY'; updateTradeTotal(); });
+  document.getElementById('buyBtn').addEventListener('focus', () => { tradeMode = 'BUY'; updateTradeTotal(); });
+  document.getElementById('sellBtn').addEventListener('mouseenter', () => { tradeMode = 'SELL'; updateTradeTotal(); });
+  document.getElementById('sellBtn').addEventListener('focus', () => { tradeMode = 'SELL'; updateTradeTotal(); });
 });

--- a/docs/trade.html
+++ b/docs/trade.html
@@ -20,6 +20,7 @@
       <label for="tradeQty">Quantity</label><br/>
       <input id="tradeQty" type="number" min="1" value="1" /><br/>
       <input id="tradeQtySlider" type="range" min="1" value="1" /><br/>
+      <div><span id="tradeTotalLabel">Total Cost:</span> $<span id="tradeTotal">0.00</span></div>
       <button type="button" id="buyBtn">Buy</button>
       <button type="button" id="sellBtn">Sell</button>
     </div>


### PR DESCRIPTION
## Summary
- display transaction total under trade slider
- compute buy/sell totals dynamically depending on which button is active
- update totals whenever quantity or symbol changes

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_686126bf0704832594d4201e07a34d4f