### PR TITLE
Align play chart starting week

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -159,7 +159,8 @@ function startGame() {
   }
   computeNetWorth(gameState);
   if (!gameState.netWorthHistory) {
-    gameState.netWorthHistory = [gameState.netWorth];
+    // Pre-fill history so the chart includes the pre-game weeks
+    gameState.netWorthHistory = Array(gameState.week).fill(gameState.netWorth);
   }
   displayUsername();
   updateStatus();

--- a/docs/js/market.js
+++ b/docs/js/market.js
@@ -7,13 +7,18 @@ function initMarketHistory() {
   marketHistory.length = 0;
   portfolioHistory.length = 0;
   if (!gameState || !gameState.prices || !gameState.prices[INDEX_SYMBOL]) return;
-  gameState.prices[INDEX_SYMBOL].forEach(week => {
+  const indexWeeks = gameState.prices[INDEX_SYMBOL];
+  const netHist = gameState.netWorthHistory || [];
+  const startIdx = Math.max(indexWeeks.length - netHist.length, indexWeeks.length - 52);
+  for (let i = startIdx; i < indexWeeks.length; i++) {
+    const week = indexWeeks[i];
     marketHistory.push(week[week.length - 1]);
-  });
+  }
   if (gameState && gameState.netWorthHistory) {
-    gameState.netWorthHistory.forEach(w => {
-      portfolioHistory.push(w);
-    });
+    const worthStart = Math.max(0, gameState.netWorthHistory.length - 52);
+    for (let i = worthStart; i < gameState.netWorthHistory.length; i++) {
+      portfolioHistory.push(gameState.netWorthHistory[i]);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- trim history arrays so the play chart starts at week 14
- prefill net worth history to include pre-game data

## Testing
- `node tests/test_player.js`


------
https://chatgpt.com/codex/tasks/task_e_686129f5bf7c8325aef541118b9d2aec