### PR TITLE
Fix trade slider max

### DIFF
--- a/docs/js/player.js
+++ b/docs/js/player.js
@@ -40,6 +40,12 @@ function calculateGainToPainRatio(returns) {
 const TRADE_COMMISSION = 4.95;
 const TRADE_FEE_RATE = 0.001; // 0.1% of trade value
 
+function calculateMaxBuy(cash, price) {
+  if (cash <= TRADE_COMMISSION || price <= 0) return 0;
+  const perShare = price * (1 + TRADE_FEE_RATE);
+  return Math.max(0, Math.floor((cash - TRADE_COMMISSION) / perShare));
+}
+
 function buyStock(state, symbol, qty, price) {
   const tradeValue = qty * price;
   const commission = TRADE_COMMISSION;
@@ -94,6 +100,7 @@ if (typeof module !== 'undefined') {
     calculateMaxDrawdown,
     calculateSharpeRatio,
     calculateGainToPainRatio,
+    calculateMaxBuy,
     TRADE_COMMISSION,
     TRADE_FEE_RATE
   };

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -55,7 +55,7 @@ function updateTradeInfo() {
 
   const slider = document.getElementById('tradeQtySlider');
   const input = document.getElementById('tradeQty');
-  const maxBuy = Math.floor(gameState.cash / price);
+  const maxBuy = calculateMaxBuy(gameState.cash, price);
   const holdings = (gameState.positions[sym] && gameState.positions[sym].qty) || 0;
   const max = Math.max(maxBuy, holdings, 1);
   slider.max = max;

--- a/tests/test_player.js
+++ b/tests/test_player.js
@@ -5,6 +5,7 @@ const {
   calculateMaxDrawdown,
   calculateSharpeRatio,
   calculateGainToPainRatio,
+  calculateMaxBuy,
   TRADE_COMMISSION,
   TRADE_FEE_RATE
 } = require('../docs/js/player.js');
@@ -57,9 +58,19 @@ function testMetrics() {
   assert.ok(gp > 2.9 && gp < 2.92);
 }
 
+function testCalculateMaxBuy() {
+  const price = 50;
+  const cash = 1000;
+  const expected = Math.floor((cash - TRADE_COMMISSION) / (price * (1 + TRADE_FEE_RATE)));
+  const qty = calculateMaxBuy(cash, price);
+  assert.strictEqual(qty, expected);
+  assert.strictEqual(calculateMaxBuy(TRADE_COMMISSION - 1, price), 0);
+}
+
 try {
   testBuySell();
   testMetrics();
+  testCalculateMaxBuy();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed');


### PR DESCRIPTION
## Summary
- prevent the trade quantity slider from exceeding an affordable buy amount
- expose a `calculateMaxBuy` helper so code and tests can compute an affordable amount
- add unit tests for `calculateMaxBuy`

## Testing
- `node tests/test_player.js`


------
https://chatgpt.com/codex/tasks/task_e_6861319c77c483259cd1f12b54a9f66d