### PR TITLE
Switch game charts to D3

### DIFF
--- a/docs/analysis.html
+++ b/docs/analysis.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Drawdown - Analysis</title>
   <link rel="stylesheet" href="css/style.css">
+  <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 <body>
   <div class="analysis-container">
@@ -21,7 +22,7 @@
       <div>Low: $<span id="low">0</span></div>
     </div>
     <div class="chart-wrapper">
-      <canvas id="companyChart" width="600" height="350"></canvas>
+      <div id="companyChart"></div>
     </div>
     <div class="analysis-nav">
       <button id="nextBtn" type="button">Next Company</button>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -103,7 +103,9 @@ button:hover {
   max-width: 600px;
 }
 
-#marketChart {
+#marketChart,
+#marketChartMobile,
+#companyChart {
   display: block;
   width: 100%;
   height: auto;
@@ -112,10 +114,24 @@ button:hover {
 }
 
 /* Ensure all charts scale proportionally */
-.chart-wrapper canvas {
+.chart-wrapper canvas,
+.chart-wrapper svg {
   width: 100%;
   height: auto;
   aspect-ratio: 600 / 350;
+}
+
+.mobile-chart {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .desktop-chart {
+    display: none;
+  }
+  .mobile-chart {
+    display: block;
+  }
 }
 
 .news {

--- a/docs/play.html
+++ b/docs/play.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Drawdown</title>
   <link rel="stylesheet" href="css/style.css">
+  <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 <body>
   <div id="status" class="status">
@@ -13,8 +14,11 @@
     <div>Rank: <span id="rank">Novice</span></div>
     <div>Cash: $<span id="cash">35000</span></div>
   </div>
-  <div class="chart-wrapper">
-    <canvas id="marketChart" width="600" height="350"></canvas>
+  <div class="chart-wrapper desktop-chart">
+    <div id="marketChart"></div>
+  </div>
+  <div class="chart-wrapper mobile-chart">
+    <div id="marketChartMobile"></div>
   </div>
   <div id="news" class="news"></div>
   <div class="menu">


### PR DESCRIPTION
## Summary
- use D3 based charts on gameplay and analysis screens
- tweak CSS for new chart containers and mobile/desktop handling
- load D3 library in affected pages
- reimplement market and company chart logic with D3.js

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_68628466a3048325ae09579aab20b04e