### PR TITLE
Revamp high score entry flow

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -258,9 +258,6 @@ function showGameOverDialog() {
 }
 
 function endGame() {
-  const afterScore = () => {
-    showGameOverDialog();
-  };
   gameState.gameOver = true;
   const done = document.getElementById('doneBtn');
   if (done) {
@@ -268,10 +265,18 @@ function endGame() {
     done.classList.add('hidden');
   }
   saveState(gameState);
-  if (window.drawdownHighScores) {
-    window.drawdownHighScores.check(gameState.netWorth, afterScore);
+  if (window.drawdownHighScores &&
+      typeof window.drawdownHighScores.prepareEntry === 'function') {
+    window.drawdownHighScores.prepareEntry(gameState.netWorth)
+      .then(needsPage => {
+        if (needsPage) {
+          window.location.href = 'new-high-score.html';
+        } else {
+          showGameOverDialog();
+        }
+      });
   } else {
-    afterScore();
+    showGameOverDialog();
   }
 }
 

--- a/docs/js/highscores.js
+++ b/docs/js/highscores.js
@@ -135,6 +135,21 @@ function promptForScoreName(defaultName) {
   });
 }
 
+// Check if a score qualifies and stash data for the entry page
+export async function prepareEntry(score) {
+  const board = await loadBoard();
+  const qualifies = board.length < MAX_SCORES ||
+    (board.length && score > board[board.length - 1].score);
+  if (!qualifies) return false;
+  const defaultName =
+    (typeof window !== 'undefined' && typeof window.getUser === 'function')
+      ? window.getUser()
+      : '';
+  sessionStorage.setItem('pendingHighScore',
+    JSON.stringify({ score, board, defaultName }));
+  return true;
+}
+
 // 8. Determine if a score qualifies and submit if so
 export async function check(score, cb) {
   const board = await loadBoard();
@@ -160,5 +175,5 @@ export async function check(score, cb) {
 
 // expose to callers when loaded as a classic script
 if (typeof window !== 'undefined') {
-  window.drawdownHighScores = { check };
+  window.drawdownHighScores = { check, prepareEntry };
 }

--- a/docs/new-high-score.html
+++ b/docs/new-high-score.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drawdown - New High Score</title>
+  <style>
+    body {
+      background-color: #000;
+      color: #33ff33;
+      font-family: 'Courier New', Courier, monospace;
+      margin: 0;
+      padding: 40px 20px;
+      text-align: center;
+    }
+    table {
+      margin: 0 auto;
+      border-collapse: collapse;
+      width: 100%;
+      max-width: 400px;
+    }
+    th, td {
+      border: 1px solid #33ff33;
+      padding: 8px;
+    }
+    .new-row {
+      color: #ff9933;
+    }
+    input {
+      background: #000;
+      color: #ff9933;
+      border: 1px solid #ff9933;
+      caret-color: #ff9933;
+    }
+    .blink-cursor {
+      border-right: 1px solid #ff9933;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink {
+      50% { border-color: transparent; }
+    }
+    .link-wrapper {
+      font-size: 0.95rem;
+      color: #33ff33;
+      text-decoration: none;
+      border: 1px solid #33ff33;
+      background: #222;
+      padding: 8px 12px;
+      margin: 20px auto;
+      width: 100%;
+      max-width: 400px;
+      display: block;
+      cursor: pointer;
+    }
+    .link-wrapper:hover {
+      background: #33ff33;
+      color: #000;
+    }
+  </style>
+</head>
+<body>
+  <h1>Congratulations! You made the high score board!</h1>
+  <table id="scoresTable"></table>
+  <a id="saveBtn" href="#" class="link-wrapper">Save My High Score</a>
+  <script type="module">
+    import { submitScore } from './js/highscores.js';
+
+    const data = sessionStorage.getItem('pendingHighScore');
+    if (!data) {
+      window.location.href = 'game-over.html';
+    } else {
+      const { score, board, defaultName } = JSON.parse(data);
+      const tbl = document.getElementById('scoresTable');
+      let inserted = false;
+      const all = [];
+      for (const entry of board) {
+        if (!inserted && score > entry.score) {
+          all.push({ player: '', score, isNew: true });
+          inserted = true;
+        }
+        all.push(entry);
+      }
+      if (!inserted && all.length < 10) {
+        all.push({ player: '', score, isNew: true });
+        inserted = true;
+      }
+      const display = all.slice(0, 10);
+      let inputEl = null;
+      tbl.innerHTML = '';
+      const header = document.createElement('tr');
+      header.innerHTML = '<th>Rank</th><th>Name</th><th>Worth</th>';
+      tbl.appendChild(header);
+      display.forEach((s, idx) => {
+        const row = document.createElement('tr');
+        if (s.isNew) {
+          row.classList.add('new-row');
+          const rank = document.createElement('td');
+          rank.textContent = idx + 1;
+          const nameCell = document.createElement('td');
+          inputEl = document.createElement('input');
+          inputEl.id = 'nameInput';
+          inputEl.type = 'text';
+          inputEl.autocomplete = 'off';
+          inputEl.value = defaultName || '';
+          inputEl.classList.add('blink-cursor');
+          nameCell.appendChild(inputEl);
+          const val = document.createElement('td');
+          val.textContent = '$' + s.score.toLocaleString();
+          row.appendChild(rank);
+          row.appendChild(nameCell);
+          row.appendChild(val);
+        } else {
+          row.innerHTML = `<td>${idx + 1}</td><td>${s.player}</td><td>$${s.score.toLocaleString()}</td>`;
+        }
+        tbl.appendChild(row);
+      });
+      document.getElementById('saveBtn').addEventListener('click', async (e) => {
+        e.preventDefault();
+        const name = (inputEl.value || defaultName || 'default').trim();
+        try {
+          await submitScore(name, score);
+        } catch (err) {
+          console.error('submitScore failed', err);
+        }
+        sessionStorage.removeItem('pendingHighScore');
+        window.location.href = 'game-over.html';
+      });
+      if (inputEl) inputEl.focus();
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated new-high-score page
- add prepareEntry() helper in highscores module
- redirect to new-high-score page when player finishes with a high score

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_68628dfff0c883259158e2b436a3e641