### PR TITLE
Update charts to recalc Y-axis on zoom

### DIFF
--- a/docs/js/analysis.js
+++ b/docs/js/analysis.js
@@ -139,7 +139,7 @@ function drawChart(history) {
   const xAxis = g.append('g')
     .attr('transform', `translate(0,${chartHeight})`)
     .call(d3.axisBottom(x).ticks(10));
-  g.append('g')
+  const yAxis = g.append('g')
     .call(d3.axisLeft(y).ticks(5).tickFormat(d => {
       return Math.abs(d) >= 1000 ? Math.round(d / 1000) + 'k' : d;
     }));
@@ -157,6 +157,19 @@ function drawChart(history) {
     .on('zoom', event => {
       const newX = event.transform.rescaleX(x);
       xAxis.call(d3.axisBottom(newX).ticks(10));
+      const [xStart, xEnd] = newX.domain();
+      const visible = [];
+      for (let i = 0; i < weeks.length; i++) {
+        if (weeks[i] >= xStart && weeks[i] <= xEnd) {
+          visible.push(history[i]);
+        }
+      }
+      if (visible.length > 0) {
+        y.domain(d3.extent(visible)).nice();
+        yAxis.call(d3.axisLeft(y).ticks(5).tickFormat(d => {
+          return Math.abs(d) >= 1000 ? Math.round(d / 1000) + 'k' : d;
+        }));
+      }
       pricePath.attr('d', d3.line()
         .x((d, i) => newX(weeks[i]))
         .y(d => y(d))

--- a/docs/js/market.js
+++ b/docs/js/market.js
@@ -88,7 +88,7 @@ function renderMarketChart() {
     const xAxis = g.append('g')
       .attr('transform', `translate(0,${chartHeight})`)
       .call(d3.axisBottom(x).ticks(10));
-    g.append('g')
+    const yAxis = g.append('g')
       .call(d3.axisLeft(y).ticks(5).tickFormat(d => d + '%'));
     g.append('text')
       .attr('x', chartWidth / 2)
@@ -97,7 +97,7 @@ function renderMarketChart() {
       .attr('fill', '#33ff33')
       .text('Week');
 
-    plot.append('line')
+    const zeroLine = plot.append('line')
       .attr('x1', 0)
       .attr('x2', chartWidth)
       .attr('y1', y(0))
@@ -136,6 +136,19 @@ function renderMarketChart() {
       .on('zoom', event => {
         const newX = event.transform.rescaleX(x);
         xAxis.call(d3.axisBottom(newX).ticks(10));
+        const [xStart, xEnd] = newX.domain();
+        const visible = [];
+        for (let i = 0; i < weeks.length; i++) {
+          if (weeks[i] >= xStart && weeks[i] <= xEnd) {
+            if (!isNaN(indexPct[i])) visible.push(indexPct[i]);
+            if (!isNaN(worthPct[i])) visible.push(worthPct[i]);
+          }
+        }
+        if (visible.length > 0) {
+          y.domain(d3.extent(visible)).nice();
+          yAxis.call(d3.axisLeft(y).ticks(5).tickFormat(d => d + '%'));
+          zeroLine.attr('y1', y(0)).attr('y2', y(0));
+        }
         indexPath.attr('d', d3.line()
           .x((d, i) => newX(weeks[i]))
           .y(d => y(d))


### PR DESCRIPTION
## Summary
- allow analysis and market charts to update the y-range when zooming or panning

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_6862c1ae8bb883259d4789e49de2ae65