### PR TITLE
Improve trading UI

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -220,6 +220,26 @@ select {
   margin-bottom: 1rem;
 }
 
+#tradeModeSelect {
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+#sellHoldingsTable {
+  margin: 0.5rem auto;
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 400px;
+}
+
+#sellHoldingsTable th,
+#sellHoldingsTable td {
+  border: 1px solid #33ff33;
+  padding: 0.5rem;
+}
+
 #tradeHistoryTable {
   margin: 1rem auto;
   border-collapse: collapse;

--- a/docs/trade.html
+++ b/docs/trade.html
@@ -13,17 +13,28 @@
       <tr><th>Worth</th><td>$<span id="tNetWorth">0</span></td></tr>
       <tr><th>Cash</th><td>$<span id="tCash">0</span></td></tr>
     </table>
-    <div id="tradeForm">
-      <label for="tradeSymbol">Symbol</label><br/>
-      <select id="tradeSymbol"></select><br/>
-      <div>Price: $<span id="tradePrice">0.00</span></div>
-      <label for="tradeQty">Quantity</label><br/>
-      <input id="tradeQty" type="number" min="1" value="1" /><br/>
-      <input id="tradeQtySlider" type="range" min="1" value="1" /><br/>
-      <div><span id="tradeTotalLabel">Total Cost:</span> $<span id="tradeTotal">0.00</span></div>
-      <button type="button" id="buyBtn">Buy</button>
-      <button type="button" id="sellBtn">Sell</button>
-    </div>
+    <div id="tradeModeSelect">
+        <button type="button" id="startBuyBtn">Buy</button>
+        <button type="button" id="startSellBtn">Sell</button>
+      </div>
+
+      <div id="sellHoldings" class="hidden">
+        <h3>Your Holdings</h3>
+        <table id="sellHoldingsTable"></table>
+      </div>
+
+      <div id="tradeForm" class="hidden">
+        <label for="tradeSymbol">Symbol</label><br/>
+        <select id="tradeSymbol"></select><br/>
+        <div>Price: $<span id="tradePrice">0.00</span></div>
+        <label for="tradeQty">Quantity</label><br/>
+        <input id="tradeQty" type="number" min="1" value="1" /><br/>
+        <input id="tradeQtySlider" type="range" min="1" value="1" /><br/>
+        <div><span id="tradeTotalLabel">Total Cost:</span> $<span id="tradeTotal">0.00</span></div>
+        <button type="button" id="buyBtn">Buy</button>
+        <button type="button" id="sellBtn">Sell</button>
+        <button type="button" id="cancelTradeBtn">Cancel</button>
+      </div>
     <div id="tradeConfirm" class="confirm-message"></div>
     <table id="tradeHistoryTable"></table>
     <div class="analysis-nav">


### PR DESCRIPTION
## Summary
- redesign trade page with separate buy and sell order flows
- show a holdings table when selling to clarify available shares
- adjust styles for new UI elements
- update trade logic for the two-path workflow

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_6863ed917a2c8325b456c35d2c2f30ba