### PR TITLE
Add greeting overlay before game starts

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -18,7 +18,7 @@ fetch('data/company_master_data.json')
     // keep mu as provided; drift direction will change week by week
     setupMarketIndex();
     ensureUser(() => {
-      startGame();
+      showGreeting(startGame);
     });
   });
 function getBeta(c) {
@@ -325,6 +325,36 @@ function showPlaceholder(msg) {
   if (typeof showMessage === 'function') {
     showMessage(msg + ' screen goes here.');
   }
+}
+
+function showGreeting(callback) {
+  const overlay = document.getElementById('greetingOverlay');
+  const startBtn = document.getElementById('greetingStart');
+  const greetText = document.getElementById('greetingText');
+  const instructText = document.getElementById('greetingInstructions');
+  if (!overlay || !startBtn) {
+    callback();
+    return;
+  }
+  if (greetText) {
+    greetText.textContent = `Alright ${getUser()}, let's pretend you know what you're doing.`;
+  }
+  if (instructText) {
+    instructText.textContent = 'Advance weeks, trade some stocks, try not to go broke.';
+  }
+  function proceed() {
+    overlay.classList.add('hidden');
+    startBtn.removeEventListener('click', proceed);
+    document.removeEventListener('keydown', keyHandler);
+    callback();
+  }
+  function keyHandler(e) {
+    if (e.key === 'Enter') proceed();
+  }
+  startBtn.addEventListener('click', proceed);
+  document.addEventListener('keydown', keyHandler);
+  overlay.classList.remove('hidden');
+  startBtn.focus();
 }
 
 const doneEl = document.getElementById('doneBtn');

--- a/docs/play.html
+++ b/docs/play.html
@@ -37,6 +37,13 @@
       <button type="button" id="usernameRandom">Random Name</button>
     </form>
   </div>
+  <div id="greetingOverlay" class="username-prompt hidden">
+    <form>
+      <p id="greetingText"></p>
+      <p id="greetingInstructions"></p>
+      <button type="button" id="greetingStart">Get On With It</button>
+    </form>
+  </div>
   <div id="scorePrompt" class="username-prompt hidden">
     <form>
       <label for="scoreInput">High score name</label><br/>


### PR DESCRIPTION
## Summary
- show greeting overlay once user selects a name
- add overlay markup in play.html
- update game.js to display new overlay before launching the game

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_68651347a4348325ad193d08cd781984