### PR TITLE
Add pie charts to portfolio page

### DIFF
--- a/docs/js/portfolio.js
+++ b/docs/js/portfolio.js
@@ -1,4 +1,5 @@
 let gameState;
+let companies = [];
 
 document.addEventListener('DOMContentLoaded', () => {
   gameState = loadState();
@@ -14,6 +15,12 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('pCash').textContent = Math.round(gameState.cash).toLocaleString();
   renderPositions();
   renderMetrics();
+  fetch('data/company_master_data.json')
+    .then(r => r.json())
+    .then(data => {
+      companies = data.companies;
+      renderPieCharts();
+    });
   const back = document.getElementById('backBtn');
   if (back) back.addEventListener('click', () => {
     const dest = sessionStorage.getItem('backTo') || 'play.html';
@@ -50,3 +57,72 @@ function renderMetrics() {
   document.getElementById('sharpeRatio').textContent = calculateSharpeRatio(rets);
   document.getElementById('gainToPain').textContent = calculateGainToPainRatio(rets);
 }
+
+function renderPieCharts() {
+  drawSectorChart();
+  drawCompanyChart();
+}
+
+function drawSectorChart() {
+  if (companies.length === 0) return;
+  const data = {};
+  data['Cash'] = gameState.cash || 0;
+  Object.keys(gameState.positions).forEach(sym => {
+    const comp = companies.find(c => c.symbol === sym);
+    if (!comp) return;
+    const weeks = gameState.prices[sym];
+    if (!weeks) return;
+    const price = weeks[weeks.length - 1][weeks[weeks.length - 1].length - 1];
+    const value = (gameState.positions[sym].qty || 0) * price;
+    const ind = comp.industry || 'Other';
+    data[ind] = (data[ind] || 0) + value;
+  });
+  drawPie('sectorChart', data);
+}
+
+function drawCompanyChart() {
+  const data = { 'Cash': gameState.cash || 0 };
+  Object.keys(gameState.positions).forEach(sym => {
+    const weeks = gameState.prices[sym];
+    if (!weeks) return;
+    const price = weeks[weeks.length - 1][weeks[weeks.length - 1].length - 1];
+    const value = (gameState.positions[sym].qty || 0) * price;
+    data[sym] = (data[sym] || 0) + value;
+  });
+  drawPie('companyChartPie', data);
+}
+
+function drawPie(id, obj) {
+  const entries = Object.keys(obj).map(k => ({ name: k, value: obj[k] })).filter(d => d.value > 0);
+  const container = d3.select('#' + id);
+  if (container.empty()) return;
+  container.selectAll('*').remove();
+  if (entries.length === 0) return;
+  const width = container.node().clientWidth;
+  const height = width;
+  const radius = Math.min(width, height) / 2;
+  const svg = container.append('svg')
+    .attr('width', width)
+    .attr('height', height)
+    .append('g')
+    .attr('transform', `translate(${width / 2},${height / 2})`);
+  const color = d3.scaleOrdinal().range(d3.schemeSet3);
+  const pie = d3.pie().sort(null).value(d => d.value);
+  const arc = d3.arc().outerRadius(radius - 10).innerRadius(0);
+  const labelArc = d3.arc().outerRadius(radius * 0.7).innerRadius(radius * 0.7);
+  const arcs = svg.selectAll('path')
+    .data(pie(entries))
+    .enter().append('path')
+    .attr('d', arc)
+    .attr('fill', d => color(d.data.name));
+  svg.selectAll('text')
+    .data(pie(entries))
+    .enter().append('text')
+    .attr('transform', d => `translate(${labelArc.centroid(d)})`)
+    .attr('dy', '0.35em')
+    .attr('text-anchor', 'middle')
+    .attr('fill', '#33ff33')
+    .attr('font-size', '0.75rem')
+    .text(d => d.data.name);
+}
+

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Drawdown - Portfolio</title>
   <link rel="stylesheet" href="css/style.css" />
+  <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 <body>
   <div class="portfolio-container">
@@ -17,6 +18,14 @@
       <tr><th>Gain to Pain</th><td><span id="gainToPain">0</span></td></tr>
     </table>
     <table id="positionsTable"></table>
+    <h2>Sector Allocation</h2>
+    <div class="chart-wrapper">
+      <div id="sectorChart"></div>
+    </div>
+    <h2>Holdings by Company</h2>
+    <div class="chart-wrapper">
+      <div id="companyChartPie"></div>
+    </div>
     <div class="analysis-nav">
       <button id="backBtn" type="button">Back to Overview</button>
     </div>


### PR DESCRIPTION
## Summary
- embed D3 on portfolio page
- show sector and company allocation charts
- compute positions and cash distribution in portfolio.js

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_6865155449ac83258064824da76afc2f