### PR TITLE
Fix greeting overlay appears only once

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -18,7 +18,14 @@ fetch('data/company_master_data.json')
     // keep mu as provided; drift direction will change week by week
     setupMarketIndex();
     ensureUser(() => {
-      showGreeting(startGame);
+      if (typeof hasSeenGreeting === 'function' && hasSeenGreeting()) {
+        startGame();
+      } else {
+        showGreeting(() => {
+          if (typeof setGreetingSeen === 'function') setGreetingSeen();
+          startGame();
+        });
+      }
     });
   });
 function getBeta(c) {

--- a/docs/js/storage.js
+++ b/docs/js/storage.js
@@ -79,3 +79,11 @@ function loadState() {
 function saveState(state) {
   localStorage.setItem(getStorageKey(), JSON.stringify(state));
 }
+
+function hasSeenGreeting() {
+  return localStorage.getItem('drawdownGreeting_' + getUser()) === '1';
+}
+
+function setGreetingSeen() {
+  localStorage.setItem('drawdownGreeting_' + getUser(), '1');
+}


### PR DESCRIPTION
## Summary
- track first-run greeting in localStorage
- show greeting only if user hasn't seen it yet

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_68651729427483258be930c89e2e625b