### PR TITLE
Fix trade order flow button labels

### DIFF
--- a/docs/trade.html
+++ b/docs/trade.html
@@ -14,8 +14,8 @@
       <tr><th>Cash</th><td>$<span id="tCash">0</span></td></tr>
     </table>
     <div id="tradeModeSelect">
-        <button type="button" id="startBuyBtn">Buy</button>
-        <button type="button" id="startSellBtn">Sell</button>
+        <button type="button" id="startBuyBtn">Buy Order</button>
+        <button type="button" id="startSellBtn">Sell Order</button>
       </div>
 
       <div id="sellHoldings" class="hidden">


### PR DESCRIPTION
## Summary
- disambiguate trading UI buttons by labeling the order-flow buttons as **Buy Order** and **Sell Order**

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_686560ef6c888325a56937e356e801ee