### PR TITLE
Update trading UI text and refresh holdings

### DIFF
--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -172,6 +172,7 @@ function doBuy() {
     showTradeDialog(trade);
     renderMetrics();
     updateTradeInfo();
+    renderSellHoldings();
     renderTradeHistory();
   }
 }
@@ -203,6 +204,7 @@ function doSell() {
     showTradeDialog(trade);
     renderMetrics();
     updateTradeInfo();
+    renderSellHoldings();
     renderTradeHistory();
   }
 }

--- a/docs/trade.html
+++ b/docs/trade.html
@@ -31,8 +31,8 @@
         <input id="tradeQty" type="number" min="1" value="1" /><br/>
         <input id="tradeQtySlider" type="range" min="1" value="1" /><br/>
         <div><span id="tradeTotalLabel">Total Cost:</span> $<span id="tradeTotal">0.00</span></div>
-        <button type="button" id="buyBtn">Buy</button>
-        <button type="button" id="sellBtn">Sell</button>
+        <button type="button" id="buyBtn">Execute Order</button>
+        <button type="button" id="sellBtn">Execute Order</button>
         <button type="button" id="cancelTradeBtn">Cancel</button>
       </div>
     <div id="tradeConfirm" class="confirm-message"></div>


### PR DESCRIPTION
## Summary
- rename Buy/Sell buttons to `Execute Order`
- refresh holdings table after executing trades

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_68657eae9c848325a48f98dd72db9f15