### PR TITLE
Enhance portfolio pie chart visibility

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -295,6 +295,8 @@ select {
 /* Smaller square pies for portfolio charts */
 .pie-chart-wrapper {
   max-width: 300px;
+  background: #111;
+  border: 1px solid #33ff33;
 }
 
 .pie-chart-wrapper svg {

--- a/docs/js/portfolio.js
+++ b/docs/js/portfolio.js
@@ -122,7 +122,7 @@ function drawPie(id, obj) {
     pat.append('rect')
       .attr('width', 8)
       .attr('height', 8)
-      .attr('fill', '#111');
+      .attr('fill', '#222');
     if (type === 'diag1') {
       pat.append('path').attr('d', 'M0,8 l8,-8 M-2,6 l4,-4 M6,10 l4,-4')
         .attr('stroke', '#66ff66').attr('stroke-width', 2);


### PR DESCRIPTION
## Summary
- lighten pattern background in pie charts
- add background and green border for pie wrappers

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_68661fea542c8325a5ceacbf37972a61