### PR TITLE
Switch portfolio pies to treemap

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -292,13 +292,3 @@ select {
   color: #66ff66;
 }
 
-/* Smaller square pies for portfolio charts */
-.pie-chart-wrapper {
-  max-width: 300px;
-  background: #111;
-  border: 1px solid #33ff33;
-}
-
-.pie-chart-wrapper svg {
-  aspect-ratio: 1 / 1;
-}

--- a/docs/js/portfolio.js
+++ b/docs/js/portfolio.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(r => r.json())
     .then(data => {
       companies = data.companies;
-      renderPieCharts();
+      renderTreemap();
     });
   const back = document.getElementById('backBtn');
   if (back) back.addEventListener('click', () => {
@@ -58,102 +58,45 @@ function renderMetrics() {
   document.getElementById('gainToPain').textContent = calculateGainToPainRatio(rets);
 }
 
-function renderPieCharts() {
-  drawSectorChart();
-  drawCompanyChart();
-}
-
-function drawSectorChart() {
-  if (companies.length === 0) return;
-  const data = {};
-  data['Cash'] = gameState.cash || 0;
-  Object.keys(gameState.positions).forEach(sym => {
-    const comp = companies.find(c => c.symbol === sym);
-    if (!comp) return;
-    const weeks = gameState.prices[sym];
-    if (!weeks) return;
-    const price = weeks[weeks.length - 1][weeks[weeks.length - 1].length - 1];
-    const value = (gameState.positions[sym].qty || 0) * price;
-    const ind = comp.industry || 'Other';
-    data[ind] = (data[ind] || 0) + value;
-  });
-  drawPie('sectorChart', data);
-}
-
-function drawCompanyChart() {
-  const data = { 'Cash': gameState.cash || 0 };
+function renderTreemap() {
+  const data = [];
   Object.keys(gameState.positions).forEach(sym => {
     const weeks = gameState.prices[sym];
     if (!weeks) return;
     const price = weeks[weeks.length - 1][weeks[weeks.length - 1].length - 1];
     const value = (gameState.positions[sym].qty || 0) * price;
-    data[sym] = (data[sym] || 0) + value;
+    if (value > 0) data.push({ name: sym, value });
   });
-  drawPie('companyChartPie', data);
+  if (gameState.cash > 0) data.push({ name: 'Cash', value: gameState.cash });
+  drawTreemap('portfolioTreemap', data);
 }
 
-function drawPie(id, obj) {
-  const entries = Object.keys(obj).map(k => ({ name: k, value: obj[k] })).filter(d => d.value > 0);
+function drawTreemap(id, data) {
   const container = d3.select('#' + id);
   if (container.empty()) return;
   container.selectAll('*').remove();
-  if (entries.length === 0) return;
+  if (data.length === 0) return;
   const width = container.node().clientWidth;
-  const height = width;
-  const radius = Math.min(width, height) / 2;
+  const height = width * 0.6;
   const svg = container.append('svg')
     .attr('width', width)
-    .attr('height', height)
-    .append('g')
-    .attr('transform', `translate(${width / 2},${height / 2})`);
-  const pie = d3.pie().sort(null).value(d => d.value);
-  const arc = d3.arc().outerRadius(radius - 10).innerRadius(0);
-  const labelArc = d3.arc().outerRadius(radius * 0.7).innerRadius(radius * 0.7);
-
-  const defs = svg.append('defs');
-  const patternTypes = ['diag1', 'diag2', 'grid', 'dots'];
-  const patPrefix = `${id}-piePattern`;
-  entries.forEach((_, i) => {
-    const type = patternTypes[i % patternTypes.length];
-    const pat = defs.append('pattern')
-      .attr('id', `${patPrefix}${i}`)
-      .attr('patternUnits', 'userSpaceOnUse')
-      .attr('width', 8)
-      .attr('height', 8);
-    pat.append('rect')
-      .attr('width', 8)
-      .attr('height', 8)
-      .attr('fill', '#222');
-    if (type === 'diag1') {
-      pat.append('path').attr('d', 'M0,8 l8,-8 M-2,6 l4,-4 M6,10 l4,-4')
-        .attr('stroke', '#66ff66').attr('stroke-width', 2);
-    } else if (type === 'diag2') {
-      pat.append('path').attr('d', 'M0,0 l8,8 M-2,2 l4,4 M6,-2 l4,4')
-        .attr('stroke', '#66ff66').attr('stroke-width', 2);
-    } else if (type === 'grid') {
-      pat.append('path').attr('d', 'M0,2 l8,0 M0,6 l8,0 M2,0 l0,8 M6,0 l0,8')
-        .attr('stroke', '#66ff66').attr('stroke-width', 2);
-    } else if (type === 'dots') {
-      pat.append('circle').attr('cx', 2).attr('cy', 2).attr('r', 1).attr('fill', '#66ff66');
-      pat.append('circle').attr('cx', 6).attr('cy', 6).attr('r', 1).attr('fill', '#66ff66');
-      pat.append('circle').attr('cx', 2).attr('cy', 6).attr('r', 1).attr('fill', '#66ff66');
-      pat.append('circle').attr('cx', 6).attr('cy', 2).attr('r', 1).attr('fill', '#66ff66');
-    }
-  });
-
-  const arcs = svg.selectAll('path')
-    .data(pie(entries))
-    .enter().append('path')
-    .attr('d', arc)
-    .attr('fill', (_, i) => `url(#${patPrefix}${i})`)
-    .attr('stroke', '#66ff66')
-    .attr('stroke-width', 1);
-  svg.selectAll('text')
-    .data(pie(entries))
-    .enter().append('text')
-    .attr('transform', d => `translate(${labelArc.centroid(d)})`)
-    .attr('dy', '0.35em')
+    .attr('height', height);
+  const root = d3.hierarchy({ children: data }).sum(d => d.value);
+  d3.treemap().size([width, height]).padding(2)(root);
+  const nodes = svg.selectAll('g')
+    .data(root.leaves())
+    .enter().append('g')
+    .attr('transform', d => `translate(${d.x0},${d.y0})`);
+  nodes.append('rect')
+    .attr('width', d => d.x1 - d.x0)
+    .attr('height', d => d.y1 - d.y0)
+    .attr('fill', '#222')
+    .attr('stroke', '#66ff66');
+  nodes.append('text')
+    .attr('x', d => (d.x1 - d.x0) / 2)
+    .attr('y', d => (d.y1 - d.y0) / 2)
     .attr('text-anchor', 'middle')
+    .attr('dy', '0.35em')
     .attr('fill', '#ccffcc')
     .attr('font-size', '0.75rem')
     .text(d => d.data.name);

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -18,13 +18,9 @@
       <tr><th>Gain to Pain</th><td><span id="gainToPain">0</span></td></tr>
     </table>
     <table id="positionsTable"></table>
-    <h2>Sector Allocation</h2>
-    <div class="chart-wrapper pie-chart-wrapper">
-      <div id="sectorChart"></div>
-    </div>
-    <h2>Holdings by Company</h2>
-    <div class="chart-wrapper pie-chart-wrapper">
-      <div id="companyChartPie"></div>
+    <h2>Portfolio Breakdown</h2>
+    <div class="chart-wrapper">
+      <div id="portfolioTreemap"></div>
     </div>
     <div class="analysis-nav">
       <button id="backBtn" type="button">Back to Overview</button>


### PR DESCRIPTION
## Summary
- remove sector/company pie charts from portfolio page
- show a treemap of holdings instead
- drop related pie-chart CSS
- implement treemap rendering in portfolio JS

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_686632f0aa0083258c111b17e6d47fea