### PR TITLE
Add option pricing and ranking tests

### DIFF
--- a/docs/js/options.js
+++ b/docs/js/options.js
@@ -1,5 +1,21 @@
+function erf(x) {
+  // approximate error function using Abramowitz and Stegun formula 7.1.26
+  const sign = Math.sign(x);
+  x = Math.abs(x);
+  const t = 1 / (1 + 0.3275911 * x);
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const expTerm = Math.exp(-x * x);
+  const poly = (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t;
+  return sign * (1 - poly * expTerm);
+}
+
 function normCdf(x) {
-  return (1 + Math.erf(x / Math.SQRT2)) / 2;
+  const erfFn = Math.erf || erf;
+  return (1 + erfFn(x / Math.SQRT2)) / 2;
 }
 
 function blackScholesPrice(S, K, r, sigma, T, type) {

--- a/docs/js/player.js
+++ b/docs/js/player.js
@@ -114,6 +114,20 @@ function computeNetWorth(state) {
   return state.netWorth;
 }
 
+function updateRank(state) {
+  const worth = state.netWorth;
+  if (worth > 1000000) {
+    state.rank = 'Tycoon';
+  } else if (worth > 250000) {
+    state.rank = 'Trader';
+  } else if (worth > 50000) {
+    state.rank = 'Apprentice';
+  } else {
+    state.rank = 'Novice';
+  }
+  return state.rank;
+}
+
 if (typeof module !== 'undefined') {
   module.exports = {
     buyStock,
@@ -123,6 +137,7 @@ if (typeof module !== 'undefined') {
     calculateSharpeRatio,
     calculateGainToPainRatio,
     calculateMaxBuy,
+    updateRank,
     TRADE_COMMISSION,
     TRADE_FEE_RATE
   };

--- a/tests/test_player.js
+++ b/tests/test_player.js
@@ -6,9 +6,11 @@ const {
   calculateSharpeRatio,
   calculateGainToPainRatio,
   calculateMaxBuy,
+  updateRank,
   TRADE_COMMISSION,
   TRADE_FEE_RATE
 } = require('../docs/js/player.js');
+const { blackScholesPrice } = require('../docs/js/options.js');
 const assert = require('assert');
 
 function testBuySell() {
@@ -67,10 +69,25 @@ function testCalculateMaxBuy() {
   assert.strictEqual(calculateMaxBuy(TRADE_COMMISSION - 1, price), 0);
 }
 
+function testBlackScholes() {
+  const call = blackScholesPrice(100, 100, 0.05, 0.2, 1, 'call');
+  const put = blackScholesPrice(100, 100, 0.05, 0.2, 1, 'put');
+  assert.ok(Math.abs(call - 10.4506) < 1e-4);
+  assert.ok(Math.abs(put - 5.5735) < 1e-4);
+}
+
+function testUpdateRank() {
+  const state = { netWorth: 50001, rank: 'Novice' };
+  updateRank(state);
+  assert.strictEqual(state.rank, 'Apprentice');
+}
+
 try {
   testBuySell();
   testMetrics();
   testCalculateMaxBuy();
+  testBlackScholes();
+  testUpdateRank();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed');


### PR DESCRIPTION
## Summary
- polyfill `erf` in `options.js` so option pricing works in Node
- export and implement `updateRank` in `player.js`
- check Black‑Scholes pricing against known values and test rank promotion

## Testing
- `node tests/test_player.js`


------
https://chatgpt.com/codex/tasks/task_e_6866f3418d6483259d7d219851fd8d6d