### PR TITLE
Clarify Apprentice promotion and options in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Play drawdown online at [drawdowngame.com](https://drawdowngame.com). Hopefully 
 
 | **Phase**              | **What Happens** |
 |------------------------|------------------------------------------------|
-| **Start Game**         | Choose new or resume; you start with $35k, a "Novice" badge and a few weeks of history. |
+| **Start Game**         | Choose new or resume; you start with $35k, a "Novice" badge and a few weeks of history. Options unlock once promoted. |
 | **Weekly Loop (up to 104)** | |
 | • Index Update         | The market chart gets another 5 days of data points. |
 | • Headlines            | News blurbs hint at coming moves. |
 | • Trade                | Check Analysis, peek at your Portfolio, then trade is you like (each trade includes a small commission and fee). |
-| • Advance Week         | Commit your trades. Prices jump, and once you pass $50k your rank can improve. |
+| • Advance Week         | Commit your trades. Prices jump; hitting $50k promotes you to Apprentice and unlocks long calls and puts. |
 | **Retire**             | Cash out any time—or after week 104—and join the high score list. |
 
 ### Portfolio Stats

--- a/docs/analysis.html
+++ b/docs/analysis.html
@@ -29,6 +29,7 @@
       <button id="prevBtn" type="button">Previous Company</button>
       <button id="backBtn" type="button">Back to Overview</button>
     </div>
+    <p class="analysis-note">Options prices are calculated using the Black-Scholes model.</p>
   </div>
   <script src="js/storage.js"></script>
   <script src="js/analysis.js"></script>

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -351,7 +351,7 @@ function showGreeting(callback) {
     greetText.textContent = `Alright ${getUser()}, let's pretend you know what you're doing.`;
   }
   if (instructText) {
-    instructText.textContent = 'Advance weeks, trade some stocks, try not to go broke.';
+    instructText.textContent = 'Advance weeks, trade some stocks, try not to go broke. Promotion to Apprentice at $50k unlocks long calls and puts.';
   }
   function proceed() {
     overlay.classList.add('hidden');


### PR DESCRIPTION
## Summary
- explain that promotion at $50k unlocks options
- mention Black–Scholes pricing on analysis page
- update greeting instructions

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_6866f4a086a8832589b80cfead0cb794