### PR TITLE
Add Apprentice promotion dialog

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -207,6 +207,7 @@ function displayUsername() {
 }
 
 function updateRank() {
+  const prev = gameState.rank;
   const worth = gameState.netWorth;
   if (worth > 1000000) {
     gameState.rank = 'Tycoon';
@@ -216,6 +217,15 @@ function updateRank() {
     gameState.rank = 'Apprentice';
   } else {
     gameState.rank = 'Novice';
+  }
+  if (gameState.rank === 'Apprentice' && prev !== 'Apprentice' &&
+      typeof hasSeenApprentice === 'function' &&
+      typeof setApprenticeSeen === 'function' &&
+      !hasSeenApprentice()) {
+    if (typeof showMessage === 'function') {
+      showMessage("Well look at that, you're an Apprentice. Options unlocked. Try not to blow up.");
+    }
+    setApprenticeSeen();
   }
 }
 

--- a/docs/js/storage.js
+++ b/docs/js/storage.js
@@ -87,3 +87,11 @@ function hasSeenGreeting() {
 function setGreetingSeen() {
   localStorage.setItem('drawdownGreeting_' + getUser(), '1');
 }
+
+function hasSeenApprentice() {
+  return localStorage.getItem('drawdownApprentice_' + getUser()) === '1';
+}
+
+function setApprenticeSeen() {
+  localStorage.setItem('drawdownApprentice_' + getUser(), '1');
+}

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -216,6 +216,7 @@ function updateTradeTotal() {
 }
 
 function updateRank() {
+  const prev = gameState.rank;
   const worth = gameState.netWorth;
   if (worth > 1000000) {
     gameState.rank = 'Tycoon';
@@ -225,6 +226,15 @@ function updateRank() {
     gameState.rank = 'Apprentice';
   } else {
     gameState.rank = 'Novice';
+  }
+  if (gameState.rank === 'Apprentice' && prev !== 'Apprentice' &&
+      typeof hasSeenApprentice === 'function' &&
+      typeof setApprenticeSeen === 'function' &&
+      !hasSeenApprentice()) {
+    if (typeof showMessage === 'function') {
+      showMessage("Well look at that, you're an Apprentice. Options unlocked. Try not to blow up.");
+    }
+    setApprenticeSeen();
   }
 }
 


### PR DESCRIPTION
## Summary
- congratulate the player when promoted to Apprentice
- track if the apprentice dialog was already shown

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_6866f915d8f883259abb178b506b7a34