### PR TITLE
Enable dropdown strike/expiry for options

### DIFF
--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -129,6 +129,36 @@ function populateOptionSymbols(list) {
   });
 }
 
+function populateOptionDetails() {
+  const sym = document.getElementById('optSymbol').value;
+  const weeksArr = gameState.prices[sym];
+  if (!weeksArr) return;
+  const week = weeksArr[weeksArr.length - 1];
+  const price = week[week.length - 1];
+
+  document.getElementById('optStockPrice').textContent = price.toFixed(2);
+
+  const strikeSelect = document.getElementById('optStrike');
+  strikeSelect.innerHTML = '';
+  const deltas = [-0.2, -0.1, 0, 0.1, 0.2];
+  deltas.forEach(d => {
+    const strike = Math.round((price * (1 + d)) / 5) * 5;
+    const opt = document.createElement('option');
+    opt.value = strike.toFixed(2);
+    opt.textContent = strike.toFixed(2);
+    strikeSelect.appendChild(opt);
+  });
+
+  const weeksSelect = document.getElementById('optWeeks');
+  weeksSelect.innerHTML = '';
+  [4, 8, 12, 16].forEach(w => {
+    const opt = document.createElement('option');
+    opt.value = w;
+    opt.textContent = w;
+    weeksSelect.appendChild(opt);
+  });
+}
+
 function updateOptionInfo() {
   const sym = document.getElementById('optSymbol').value;
   const strike = parseFloat(document.getElementById('optStrike').value) || 0;
@@ -139,6 +169,7 @@ function updateOptionInfo() {
   if (!weeksArr || !bsPrice) return;
   const week = weeksArr[weeksArr.length - 1];
   const S = week[week.length - 1];
+  document.getElementById('optStockPrice').textContent = S.toFixed(2);
   const premium = bsPrice(S, strike, OPTION_RISK_FREE_RATE, OPTION_VOLATILITY,
                          weeks / 52, type);
   document.getElementById('optPremium').textContent = premium.toFixed(2);
@@ -381,6 +412,7 @@ document.addEventListener('DOMContentLoaded', () => {
       renderTradeHistory();
       if (gameState.rank !== 'Novice') {
         populateOptionSymbols(companies.filter(c => !c.isIndex));
+        populateOptionDetails();
         document.getElementById('optionsForm').classList.remove('hidden');
         updateOptionInfo();
         renderSellOptions();
@@ -403,10 +435,13 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('cancelTradeBtn').addEventListener('click', hideOrderForm);
 
   if (gameState.rank !== 'Novice') {
-    document.getElementById('optSymbol').addEventListener('change', updateOptionInfo);
+    document.getElementById('optSymbol').addEventListener('change', () => {
+      populateOptionDetails();
+      updateOptionInfo();
+    });
     document.getElementById('optType').addEventListener('change', updateOptionInfo);
-    document.getElementById('optStrike').addEventListener('input', updateOptionInfo);
-    document.getElementById('optWeeks').addEventListener('input', updateOptionInfo);
+    document.getElementById('optStrike').addEventListener('change', updateOptionInfo);
+    document.getElementById('optWeeks').addEventListener('change', updateOptionInfo);
     document.getElementById('optQty').addEventListener('input', updateOptionInfo);
     document.getElementById('optBuyBtn').addEventListener('click', doBuyOption);
     document.getElementById('optSellBtn').addEventListener('click', doSellOption);

--- a/docs/trade.html
+++ b/docs/trade.html
@@ -45,10 +45,12 @@
           <option value="call">Call</option>
           <option value="put">Put</option>
         </select><br/>
+        <label for="optStockPrice">Current Price</label><br/>
+        $<span id="optStockPrice">0.00</span><br/>
         <label for="optStrike">Strike</label><br/>
-        <input id="optStrike" type="number" /><br/>
+        <select id="optStrike"></select><br/>
         <label for="optWeeks">Weeks to Expiry</label><br/>
-        <input id="optWeeks" type="number" min="1" value="4" /><br/>
+        <select id="optWeeks"></select><br/>
         <label for="optQty">Contracts</label><br/>
         <input id="optQty" type="number" min="1" value="1" /><br/>
         <div>Premium: $<span id="optPremium">0.00</span></div>


### PR DESCRIPTION
## Summary
- add UI elements for picking option strike and expiry
- auto-populate strike choices around the current stock price
- keep current stock price visible when trading options
- update option listeners for new dropdown fields

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_6866fafb0eec8325900dabf7c5d2ef31