### PR TITLE
Remove promotion text from greeting overlay

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -361,7 +361,7 @@ function showGreeting(callback) {
     greetText.textContent = `Alright ${getUser()}, let's pretend you know what you're doing.`;
   }
   if (instructText) {
-    instructText.textContent = 'Advance weeks, trade some stocks, try not to go broke. Promotion to Apprentice at $50k unlocks long calls and puts.';
+    instructText.textContent = 'Advance weeks, trade some stocks, try not to go broke.';
   }
   function proceed() {
     overlay.classList.add('hidden');


### PR DESCRIPTION
## Summary
- edit greeting instructions so that the promotion blurb is gone

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_686700b7b6d08325a755f5a1ebf27cef