### PR TITLE
Prevent rank demotion

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -206,17 +206,27 @@ function displayUsername() {
   }
 }
 
+const RANK_ORDER = ['Novice', 'Apprentice', 'Trader', 'Tycoon'];
+
+function rankIndex(rank) {
+  return RANK_ORDER.indexOf(rank);
+}
+
 function updateRank() {
   const prev = gameState.rank;
   const worth = gameState.netWorth;
+  let newRank;
   if (worth > 1000000) {
-    gameState.rank = 'Tycoon';
+    newRank = 'Tycoon';
   } else if (worth > 250000) {
-    gameState.rank = 'Trader';
+    newRank = 'Trader';
   } else if (worth > 50000) {
-    gameState.rank = 'Apprentice';
+    newRank = 'Apprentice';
   } else {
-    gameState.rank = 'Novice';
+    newRank = 'Novice';
+  }
+  if (rankIndex(newRank) > rankIndex(gameState.rank)) {
+    gameState.rank = newRank;
   }
   if (gameState.rank === 'Apprentice' && prev !== 'Apprentice' &&
       typeof hasSeenApprentice === 'function' &&

--- a/docs/js/player.js
+++ b/docs/js/player.js
@@ -114,16 +114,26 @@ function computeNetWorth(state) {
   return state.netWorth;
 }
 
+const RANK_ORDER = ['Novice', 'Apprentice', 'Trader', 'Tycoon'];
+
+function rankIndex(rank) {
+  return RANK_ORDER.indexOf(rank);
+}
+
 function updateRank(state) {
   const worth = state.netWorth;
+  let newRank;
   if (worth > 1000000) {
-    state.rank = 'Tycoon';
+    newRank = 'Tycoon';
   } else if (worth > 250000) {
-    state.rank = 'Trader';
+    newRank = 'Trader';
   } else if (worth > 50000) {
-    state.rank = 'Apprentice';
+    newRank = 'Apprentice';
   } else {
-    state.rank = 'Novice';
+    newRank = 'Novice';
+  }
+  if (rankIndex(newRank) > rankIndex(state.rank)) {
+    state.rank = newRank;
   }
   return state.rank;
 }

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -246,17 +246,27 @@ function updateTradeTotal() {
   if (span) span.textContent = total.toFixed(2);
 }
 
+const RANK_ORDER = ['Novice', 'Apprentice', 'Trader', 'Tycoon'];
+
+function rankIndex(rank) {
+  return RANK_ORDER.indexOf(rank);
+}
+
 function updateRank() {
   const prev = gameState.rank;
   const worth = gameState.netWorth;
+  let newRank;
   if (worth > 1000000) {
-    gameState.rank = 'Tycoon';
+    newRank = 'Tycoon';
   } else if (worth > 250000) {
-    gameState.rank = 'Trader';
+    newRank = 'Trader';
   } else if (worth > 50000) {
-    gameState.rank = 'Apprentice';
+    newRank = 'Apprentice';
   } else {
-    gameState.rank = 'Novice';
+    newRank = 'Novice';
+  }
+  if (rankIndex(newRank) > rankIndex(gameState.rank)) {
+    gameState.rank = newRank;
   }
   if (gameState.rank === 'Apprentice' && prev !== 'Apprentice' &&
       typeof hasSeenApprentice === 'function' &&

--- a/tests/test_player.js
+++ b/tests/test_player.js
@@ -82,12 +82,22 @@ function testUpdateRank() {
   assert.strictEqual(state.rank, 'Apprentice');
 }
 
+function testRankNeverDecreases() {
+  const state = { netWorth: 100000, rank: 'Novice' };
+  updateRank(state);
+  assert.strictEqual(state.rank, 'Apprentice');
+  state.netWorth = 40000;
+  updateRank(state);
+  assert.strictEqual(state.rank, 'Apprentice');
+}
+
 try {
   testBuySell();
   testMetrics();
   testCalculateMaxBuy();
   testBlackScholes();
   testUpdateRank();
+  testRankNeverDecreases();
   console.log('All tests passed');
 } catch (err) {
   console.error('Test failed');


### PR DESCRIPTION
## Summary
- keep player rank from decreasing once they reach a new tier
- update rank logic in game, trade, and player modules
- add regression test for non-decreasing rank

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_686701eb0e688325bc5e020073e4127c