### PR TITLE
Fix rank demotion

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -209,14 +209,14 @@ function displayUsername() {
 function updateRank() {
   const prev = gameState.rank;
   const worth = gameState.netWorth;
-  if (worth > 1000000) {
-    gameState.rank = 'Tycoon';
-  } else if (worth > 250000) {
-    gameState.rank = 'Trader';
-  } else if (worth > 50000) {
-    gameState.rank = 'Apprentice';
-  } else {
-    gameState.rank = 'Novice';
+  const ranks = ['Novice', 'Apprentice', 'Trader', 'Tycoon'];
+  const prevIndex = ranks.indexOf(prev);
+  const newIndex = worth > 1000000 ? 3
+                   : worth > 250000 ? 2
+                   : worth > 50000 ? 1
+                   : 0;
+  if (newIndex > prevIndex) {
+    gameState.rank = ranks[newIndex];
   }
   if (gameState.rank === 'Apprentice' && prev !== 'Apprentice' &&
       typeof hasSeenApprentice === 'function' &&

--- a/docs/js/player.js
+++ b/docs/js/player.js
@@ -116,14 +116,14 @@ function computeNetWorth(state) {
 
 function updateRank(state) {
   const worth = state.netWorth;
-  if (worth > 1000000) {
-    state.rank = 'Tycoon';
-  } else if (worth > 250000) {
-    state.rank = 'Trader';
-  } else if (worth > 50000) {
-    state.rank = 'Apprentice';
-  } else {
-    state.rank = 'Novice';
+  const ranks = ['Novice', 'Apprentice', 'Trader', 'Tycoon'];
+  const prevIndex = ranks.indexOf(state.rank);
+  const newIndex = worth > 1000000 ? 3
+                   : worth > 250000 ? 2
+                   : worth > 50000 ? 1
+                   : 0;
+  if (newIndex > prevIndex) {
+    state.rank = ranks[newIndex];
   }
   return state.rank;
 }

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -249,14 +249,14 @@ function updateTradeTotal() {
 function updateRank() {
   const prev = gameState.rank;
   const worth = gameState.netWorth;
-  if (worth > 1000000) {
-    gameState.rank = 'Tycoon';
-  } else if (worth > 250000) {
-    gameState.rank = 'Trader';
-  } else if (worth > 50000) {
-    gameState.rank = 'Apprentice';
-  } else {
-    gameState.rank = 'Novice';
+  const ranks = ['Novice', 'Apprentice', 'Trader', 'Tycoon'];
+  const prevIndex = ranks.indexOf(prev);
+  const newIndex = worth > 1000000 ? 3
+                   : worth > 250000 ? 2
+                   : worth > 50000 ? 1
+                   : 0;
+  if (newIndex > prevIndex) {
+    gameState.rank = ranks[newIndex];
   }
   if (gameState.rank === 'Apprentice' && prev !== 'Apprentice' &&
       typeof hasSeenApprentice === 'function' &&

--- a/tests/test_player.js
+++ b/tests/test_player.js
@@ -80,6 +80,12 @@ function testUpdateRank() {
   const state = { netWorth: 50001, rank: 'Novice' };
   updateRank(state);
   assert.strictEqual(state.rank, 'Apprentice');
+  state.netWorth = 40000;
+  updateRank(state);
+  assert.strictEqual(state.rank, 'Apprentice');
+  state.netWorth = 300000;
+  updateRank(state);
+  assert.strictEqual(state.rank, 'Trader');
 }
 
 try {


### PR DESCRIPTION
## Summary
- keep rank promotions permanent in browser game code
- add matching logic to shared player module
- test upward-only rank changes

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_6867abf84c508325a3548723b585a7bb