### PR TITLE
Replace ascii art on apprentice page

### DIFF
--- a/docs/apprentice.html
+++ b/docs/apprentice.html
@@ -5,44 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Drawdown - Apprentice</title>
   <link rel="stylesheet" href="css/style.css">
-  <style>
-    pre.fireworks {
-      font-weight: bold;
-      white-space: pre;
-      line-height: 1.2;
-    }
-    .green { color: #33ff33; }
-    .amber { color: #ffbf00; }
-  </style>
 </head>
 <body>
   <h1>Promotion Achieved</h1>
-  <pre class="fireworks green">
-       ______
-      /      \
-     /________\
-    | .--. .--. |
-    | |  | |  | |
-    | |__|_|__| |
-    |  .----.   |
-    | /$$$$\   |
-    | \____/   |
-     \        /
-      '------'
-  </pre>
-  <pre class="fireworks amber">
-       ______
-      /      \
-     /________\
-    | .--. .--. |
-    | |  | |  | |
-    | |__|_|__| |
-    |  .----.   |
-    | /$$$$\   |
-    | \____/   |
-     \        /
-      '------'
-  </pre>
+  <img src="images/apprentice.png" alt="Apprentice">
   <p>Congratulations, you've stumbled your way up to <strong>Apprentice</strong>.</p>
   <p>Wall Street now trusts you with the volatile world of stock options.</p>
   <p>Don't spend all your premium money in one place.</p>


### PR DESCRIPTION
## Summary
- remove inline fireworks style and ascii art
- show `docs/images/apprentice.png` in apprentice congratulations page

## Testing
- `node tests/test_player.js`


------
https://chatgpt.com/codex/tasks/task_e_686816c7ac08832590784dbe89940e1b