### PR TITLE
Center content on apprentice page

### DIFF
--- a/docs/apprentice.html
+++ b/docs/apprentice.html
@@ -7,12 +7,14 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1>Promotion Achieved</h1>
-  <img src="images/apprentice.png" alt="Apprentice">
-  <p>Congratulations, you've stumbled your way up to <strong>Apprentice</strong>.</p>
-  <p>Wall Street now trusts you with the volatile world of stock options.</p>
-  <p>Don't spend all your premium money in one place.</p>
-  <button class="link-wrapper" onclick="window.location.href='play.html'">Back to the Game</button>
+  <div class="promotion-container">
+    <h1>Promotion Achieved</h1>
+    <img src="images/apprentice.png" alt="Apprentice">
+    <p>Congratulations, you've stumbled your way up to <strong>Apprentice</strong>.</p>
+    <p>Wall Street now trusts you with the volatile world of stock options.</p>
+    <p>Don't spend all your premium money in one place.</p>
+    <button class="link-wrapper" onclick="window.location.href='play.html'">Back to the Game</button>
+  </div>
   <script src="js/storage.js"></script>
   <script>
     if (typeof setApprenticeSeen === 'function') {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -320,3 +320,9 @@ select {
   color: #66ff66;
 }
 
+.promotion-container {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+}
+


### PR DESCRIPTION
## Summary
- wrap apprentice promotion text in a new `promotion-container` div
- add `.promotion-container` CSS class to center the page

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_6868393fc0088325bc207aeb822d20a6