### PR TITLE
Redirect high score entry to staging page

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -289,7 +289,7 @@ function endGame() {
     window.drawdownHighScores.prepareEntry(gameState.netWorth)
       .then(needsPage => {
         if (needsPage) {
-          window.location.href = 'new-high-score.html';
+          window.location.href = 'staging.html';
         } else {
           showGameOverDialog();
         }

--- a/docs/staging.html
+++ b/docs/staging.html
@@ -64,14 +64,13 @@
   <a id="saveBtn" href="#" class="link-wrapper">Save My High Score</a>
   <p><a href="index.html">Back</a></p>
   <script type="module">
-    import { initScores, loadBoard, submitScore } from './js/highscores.js';
+    import { submitScore } from './js/highscores.js';
 
-    document.addEventListener('DOMContentLoaded', async () => {
-      await initScores();
-      const board = await loadBoard();
-      const lowest = board.length ? board[board.length - 1].score : 0;
-      const score = lowest + 1;
-      const defaultName = '';
+    const data = sessionStorage.getItem('pendingHighScore');
+    if (!data) {
+      window.location.href = 'game-over.html';
+    } else {
+      const { score, board, defaultName } = JSON.parse(data);
       const tbl = document.getElementById('scoresTable');
       let inserted = false;
       const all = [];
@@ -103,7 +102,7 @@
           inputEl.id = 'nameInput';
           inputEl.type = 'text';
           inputEl.autocomplete = 'off';
-          inputEl.value = defaultName;
+          inputEl.value = defaultName || '';
           inputEl.classList.add('blink-cursor');
           nameCell.appendChild(inputEl);
           const val = document.createElement('td');
@@ -124,10 +123,11 @@
         } catch (err) {
           console.error('submitScore failed', err);
         }
-        window.location.href = 'high-scores.html';
+        sessionStorage.removeItem('pendingHighScore');
+        window.location.href = 'game-over.html';
       });
       if (inputEl) inputEl.focus();
-    });
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `staging.html` when a new high score needs a name
- reuse the high score entry script from `new-high-score.html` in `staging.html`

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_686e525f8d388325bc7ee0cbfd230b96