### PR TITLE
Fix high score origin

### DIFF
--- a/docs/js/canonical.js
+++ b/docs/js/canonical.js
@@ -1,0 +1,8 @@
+(() => {
+  const expectedProtocol = 'https:';
+  const expectedHost = 'drawdowngame.com';
+  if (location.protocol !== expectedProtocol || location.host !== expectedHost) {
+    const newUrl = `${expectedProtocol}//${expectedHost}${location.pathname}${location.search}${location.hash}`;
+    location.replace(newUrl);
+  }
+})();

--- a/docs/play.html
+++ b/docs/play.html
@@ -6,6 +6,7 @@
   <title>Drawdown</title>
   <link rel="stylesheet" href="css/style.css">
   <script src="https://d3js.org/d3.v7.min.js"></script>
+  <script src="js/canonical.js"></script>
 </head>
 <body>
   <div id="status" class="status">

--- a/docs/staging.html
+++ b/docs/staging.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Drawdown - High Score Staging</title>
+  <script src="js/canonical.js"></script>
   <style>
     body {
       background-color: #000;


### PR DESCRIPTION
## Summary
- add canonical origin enforcement script
- load canonical checker on play and staging pages

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_686e546578388325b3bfdef7e64ef74c