### PR TITLE
Move analysis into trading

### DIFF
--- a/docs/game-over.html
+++ b/docs/game-over.html
@@ -22,7 +22,6 @@
   </div>
   <div id="news" class="news"></div>
   <div class="menu">
-    <button id="dataBtn">Analysis</button>
     <button id="portfolioBtn">Portfolio</button>
     <button id="scoresBtn">High Scores</button>
     <button id="newGameBtn">Start New Game</button>

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -378,10 +378,6 @@ function showGreeting(callback) {
 
 const doneEl = document.getElementById('doneBtn');
 if (doneEl) doneEl.addEventListener('click', nextWeek);
-const dataEl = document.getElementById('dataBtn');
-if (dataEl) dataEl.addEventListener('click', () => {
-  window.location.href = 'analysis.html';
-});
 // TODO: replace placeholder with a full portfolio screen showing
 // open positions and trading performance metrics like max drawdown,
 // sharpe ratio, and gain to pain ratio.

--- a/docs/play.html
+++ b/docs/play.html
@@ -24,7 +24,6 @@
   <div id="news" class="news"></div>
   <div class="menu">
     <button id="doneBtn" class="advance">Advance to Next Week</button>
-    <button id="dataBtn">Analysis</button>
     <button id="tradeBtn" onclick="location.href='trade.html'">Trade</button>
     <button id="portfolioBtn">Portfolio</button>
     <button id="cashOutBtn">Retire</button>

--- a/docs/trade.html
+++ b/docs/trade.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Drawdown - Trade</title>
   <link rel="stylesheet" href="css/style.css" />
+  <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 <body>
   <div class="trade-container">
@@ -26,6 +27,19 @@
       <div id="tradeForm" class="hidden">
         <label for="tradeSymbol">Symbol</label><br/>
         <select id="tradeSymbol"></select><br/>
+        <div id="analysisPanel" class="hidden">
+          <div id="metrics">
+            <div>Price: $<span id="price">0</span></div>
+            <div>Volatility: <span id="volatility">0</span></div>
+            <div>Average: $<span id="average">0</span></div>
+            <div>High: $<span id="high">0</span></div>
+            <div>Low: $<span id="low">0</span></div>
+          </div>
+          <div class="chart-wrapper">
+            <div id="companyChart"></div>
+          </div>
+          <p class="analysis-note">Options prices are calculated using the Black-Scholes model.</p>
+        </div>
         <div>Price: $<span id="tradePrice">0.00</span></div>
         <label for="tradeQty">Quantity</label><br/>
         <input id="tradeQty" type="number" min="1" value="1" /><br/>


### PR DESCRIPTION
## Summary
- remove Analysis button from play/game-over pages and script
- add D3 chart and stats panel inside trading page
- show/hide analysis panel when placing orders
- update trade script with charting logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f8eb137e48325a2888302aa0dc774