### PR TITLE
Create dedicated trading pages

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,7 +1,18 @@
 * { box-sizing: border-box; }
+
+:root {
+  --accent-color: #33ff33;
+  --accent-color-light: #66ff66;
+}
+
+body.amber {
+  --accent-color: #ffbf00;
+  --accent-color-light: #ffcf40;
+}
+
 body {
   background: #000;
-  color: #33ff33;
+  color: var(--accent-color);
   font-family: 'Courier New', Courier, monospace;
   margin: 0;
   padding: 2rem;
@@ -16,19 +27,19 @@ input, button {
 
 input {
   background: #000;
-  color: #33ff33;
-  border: 1px solid #33ff33;
+  color: var(--accent-color);
+  border: 1px solid var(--accent-color);
 }
 
 button {
   background: #222;
-  color: #33ff33;
-  border: 1px solid #33ff33;
+  color: var(--accent-color);
+  border: 1px solid var(--accent-color);
   cursor: pointer;
 }
 
 button:hover {
-  background: #33ff33;
+  background: var(--accent-color);
   color: #000;
 }
 
@@ -44,7 +55,7 @@ button:hover {
 #sellOptionsTable,
 #sellOptionsTable th,
 #sellOptionsTable td {
-  color: #ffbf00;
+  color: var(--accent-color);
 }
 
 #optionsForm input,
@@ -52,11 +63,11 @@ button:hover {
 #optionsForm button,
 #sellOptionsTable th,
 #sellOptionsTable td {
-  border-color: #ffbf00;
+  border-color: var(--accent-color);
 }
 
 #optionsForm button:hover {
-  background: #ffbf00;
+  background: var(--accent-color);
   color: #000;
 }
 
@@ -180,7 +191,7 @@ button:hover {
   content: '\25ba';
   position: absolute;
   left: 0;
-  color: #33ff33;
+  color: var(--accent-color);
 }
 
 .username {
@@ -204,7 +215,7 @@ button:hover {
 
 .username-prompt form {
   background: #000;
-  border: 1px solid #33ff33;
+  border: 1px solid var(--accent-color);
   padding: 1rem;
   text-align: center;
 }
@@ -225,8 +236,8 @@ button:hover {
 
 select {
   background: #000;
-  color: #33ff33;
-  border: 1px solid #33ff33;
+  color: var(--accent-color);
+  border: 1px solid var(--accent-color);
   padding: 0.5rem;
 }
 
@@ -265,7 +276,7 @@ select {
 
 #sellHoldingsTable th,
 #sellHoldingsTable td {
-  border: 1px solid #33ff33;
+  border: 1px solid var(--accent-color);
   padding: 0.5rem;
 }
 
@@ -278,18 +289,18 @@ select {
 
 #tradeHistoryTable th,
 #tradeHistoryTable td {
-  border: 1px solid #33ff33;
+  border: 1px solid var(--accent-color);
   padding: 0.5rem;
 }
 
 .confirm-message {
   margin: 0.5rem auto;
-  color: #66ff66;
+  color: var(--accent-color-light);
 }
 
 #tradeQtySlider {
   width: 100%;
-  accent-color: #33ff33;
+  accent-color: var(--accent-color);
   /* Ensure mobile devices treat slider drag as a UI interaction */
   touch-action: none;
 }
@@ -312,13 +323,13 @@ select {
 .metrics-table td,
 #positionsTable th,
 #positionsTable td {
-  border: 1px solid #33ff33;
+  border: 1px solid var(--accent-color);
   padding: 0.5rem;
 }
 
 .final-worth {
   font-weight: bold;
-  color: #66ff66;
+  color: var(--accent-color-light);
 }
 
 .promotion-container {

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -399,7 +399,7 @@ function populateTradeSymbols() {
 }
 
 function openTrade() {
-  window.location.href = 'trade.html';
+  window.location.href = 'trade-stocks.html';
 }
 
 const tradeEl = document.getElementById('tradeBtn');

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -179,6 +179,7 @@ function updateOptionInfo() {
   const commission = TRADE_COMMISSION;
   const fees = +(tradeValue * TRADE_FEE_RATE).toFixed(2);
   document.getElementById('optTotal').textContent = (tradeValue + commission + fees).toFixed(2);
+  updateAnalysisPanel();
 }
 
 function showOrderForm(mode) {
@@ -361,7 +362,12 @@ function drawChart(history) {
 }
 
 function updateAnalysisPanel() {
-  const sym = document.getElementById('tradeSymbol').value;
+  const tradeSel = document.getElementById('tradeSymbol');
+  const optSel = document.getElementById('optSymbol');
+  const sym = tradeSel ? tradeSel.value : (optSel ? optSel.value : null);
+  if (!sym) return;
+  const panel = document.getElementById('analysisPanel');
+  if (panel) panel.classList.remove('hidden');
   const historyWeeks = gameState.prices[sym] || [];
   const closes = historyWeeks.map(w => w[w.length - 1]);
   drawChart(closes);
@@ -543,41 +549,57 @@ document.addEventListener('DOMContentLoaded', () => {
       companies = data.companies;
       renderMetrics();
       renderTradeHistory();
-      if (gameState.rank !== 'Novice') {
+      const optForm = document.getElementById('optionsForm');
+      if (gameState.rank !== 'Novice' && optForm) {
         populateOptionSymbols(companies.filter(c => !c.isIndex));
         populateOptionDetails();
-        document.getElementById('optionsForm').classList.remove('hidden');
+        optForm.classList.remove('hidden');
         updateOptionInfo();
         renderSellOptions();
       }
     });
 
-  document.getElementById('tradeSymbol').addEventListener('change', updateTradeInfo);
-  document.getElementById('tradeQtySlider').addEventListener('input', e => {
-    document.getElementById('tradeQty').value = e.target.value;
+  const tradeSymbol = document.getElementById('tradeSymbol');
+  if (tradeSymbol) tradeSymbol.addEventListener('change', updateTradeInfo);
+  const tradeQtySlider = document.getElementById('tradeQtySlider');
+  const tradeQtyInput = document.getElementById('tradeQty');
+  if (tradeQtySlider) tradeQtySlider.addEventListener('input', e => {
+    if (tradeQtyInput) tradeQtyInput.value = e.target.value;
     updateTradeTotal();
   });
-  document.getElementById('tradeQty').addEventListener('input', e => {
-    document.getElementById('tradeQtySlider').value = e.target.value;
+  if (tradeQtyInput) tradeQtyInput.addEventListener('input', e => {
+    if (tradeQtySlider) tradeQtySlider.value = e.target.value;
     updateTradeTotal();
   });
-  document.getElementById('buyBtn').addEventListener('click', doBuy);
-  document.getElementById('sellBtn').addEventListener('click', doSell);
-  document.getElementById('startBuyBtn').addEventListener('click', () => showOrderForm('BUY'));
-  document.getElementById('startSellBtn').addEventListener('click', () => showOrderForm('SELL'));
-  document.getElementById('cancelTradeBtn').addEventListener('click', hideOrderForm);
+  const buyBtn = document.getElementById('buyBtn');
+  if (buyBtn) buyBtn.addEventListener('click', doBuy);
+  const sellBtn = document.getElementById('sellBtn');
+  if (sellBtn) sellBtn.addEventListener('click', doSell);
+  const startBuyBtn = document.getElementById('startBuyBtn');
+  if (startBuyBtn) startBuyBtn.addEventListener('click', () => showOrderForm('BUY'));
+  const startSellBtn = document.getElementById('startSellBtn');
+  if (startSellBtn) startSellBtn.addEventListener('click', () => showOrderForm('SELL'));
+  const cancelTradeBtn = document.getElementById('cancelTradeBtn');
+  if (cancelTradeBtn) cancelTradeBtn.addEventListener('click', hideOrderForm);
 
   if (gameState.rank !== 'Novice') {
-    document.getElementById('optSymbol').addEventListener('change', () => {
+    const optSymbol = document.getElementById('optSymbol');
+    if (optSymbol) optSymbol.addEventListener('change', () => {
       populateOptionDetails();
       updateOptionInfo();
     });
-    document.getElementById('optType').addEventListener('change', updateOptionInfo);
-    document.getElementById('optStrike').addEventListener('change', updateOptionInfo);
-    document.getElementById('optWeeks').addEventListener('change', updateOptionInfo);
-    document.getElementById('optQty').addEventListener('input', updateOptionInfo);
-    document.getElementById('optBuyBtn').addEventListener('click', doBuyOption);
-    document.getElementById('optSellBtn').addEventListener('click', doSellOption);
+    const optType = document.getElementById('optType');
+    if (optType) optType.addEventListener('change', updateOptionInfo);
+    const optStrike = document.getElementById('optStrike');
+    if (optStrike) optStrike.addEventListener('change', updateOptionInfo);
+    const optWeeks = document.getElementById('optWeeks');
+    if (optWeeks) optWeeks.addEventListener('change', updateOptionInfo);
+    const optQty = document.getElementById('optQty');
+    if (optQty) optQty.addEventListener('input', updateOptionInfo);
+    const optBuyBtn = document.getElementById('optBuyBtn');
+    if (optBuyBtn) optBuyBtn.addEventListener('click', doBuyOption);
+    const optSellBtn = document.getElementById('optSellBtn');
+    if (optSellBtn) optSellBtn.addEventListener('click', doSellOption);
   }
 });
 

--- a/docs/play.html
+++ b/docs/play.html
@@ -24,7 +24,8 @@
   <div id="news" class="news"></div>
   <div class="menu">
     <button id="doneBtn" class="advance">Advance to Next Week</button>
-    <button id="tradeBtn" onclick="location.href='trade.html'">Trade</button>
+    <button id="tradeStocksBtn" onclick="location.href='trade-stocks.html'">Trade Stocks</button>
+    <button id="tradeOptionsBtn" onclick="location.href='trade-options.html'">Trade Stock Options</button>
     <button id="portfolioBtn">Portfolio</button>
     <button id="cashOutBtn">Retire</button>
   </div>

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drawdown - Trade Options</title>
+  <link rel="stylesheet" href="css/style.css" />
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+</head>
+<body class="amber">
+  <div class="trade-container">
+    <h1>Trade</h1>
+    <table class="metrics-table">
+      <tr><th>Worth</th><td>$<span id="tNetWorth">0</span></td></tr>
+      <tr><th>Cash</th><td>$<span id="tCash">0</span></td></tr>
+    </table>
+    <div id="optionsForm">
+        <h3>Options</h3>
+        <label for="optSymbol">Symbol</label><br/>
+        <select id="optSymbol"></select><br/>
+        <div id="analysisPanel" class="hidden">
+          <div id="metrics">
+            <div>Price: $<span id="price">0</span></div>
+            <div>Volatility: <span id="volatility">0</span></div>
+            <div>Average: $<span id="average">0</span></div>
+            <div>High: $<span id="high">0</span></div>
+            <div>Low: $<span id="low">0</span></div>
+          </div>
+          <div class="chart-wrapper">
+            <div id="companyChart"></div>
+          </div>
+          <p class="analysis-note">Options prices are calculated using the Black-Scholes model.</p>
+        </div>
+        <label for="optType">Type</label><br/>
+        <select id="optType">
+          <option value="call">Call</option>
+          <option value="put">Put</option>
+        </select><br/>
+        <label for="optStockPrice">Current Price</label><br/>
+        $<span id="optStockPrice">0.00</span><br/>
+        <label for="optStrike">Strike</label><br/>
+        <select id="optStrike"></select><br/>
+        <label for="optWeeks">Weeks to Expiry</label><br/>
+        <select id="optWeeks"></select><br/>
+        <label for="optQty">Contracts</label><br/>
+        <input id="optQty" type="number" min="1" value="1" /><br/>
+        <div>Premium: $<span id="optPremium">0.00</span></div>
+        <div>Total Cost: $<span id="optTotal">0.00</span></div>
+        <button type="button" id="optBuyBtn">Buy Option</button>
+        <button type="button" id="optSellBtn">Sell Option</button>
+      </div>
+      <div id="optionsHoldings" class="hidden">
+        <h3>Your Options</h3>
+        <table id="sellOptionsTable"></table>
+      </div>
+    <div id="tradeConfirm" class="confirm-message"></div>
+    <table id="tradeHistoryTable"></table>
+    <div class="analysis-nav">
+      <button type="button" onclick="location.href='play.html'">Back</button>
+    </div>
+  </div>
+  <script src="js/storage.js"></script>
+  <script src="js/options.js"></script>
+  <script src="js/player.js"></script>
+  <script src="js/dialog.js"></script>
+  <script src="js/trade.js"></script>
+</body>
+</html>

--- a/docs/trade-stocks.html
+++ b/docs/trade-stocks.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drawdown - Trade Stocks</title>
+  <link rel="stylesheet" href="css/style.css" />
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+</head>
+<body>
+  <div class="trade-container">
+    <h1>Trade</h1>
+    <table class="metrics-table">
+      <tr><th>Worth</th><td>$<span id="tNetWorth">0</span></td></tr>
+      <tr><th>Cash</th><td>$<span id="tCash">0</span></td></tr>
+    </table>
+    <div id="tradeModeSelect">
+        <button type="button" id="startBuyBtn">Buy Order</button>
+        <button type="button" id="startSellBtn">Sell Order</button>
+      </div>
+
+      <div id="sellHoldings" class="hidden">
+        <h3>Your Holdings</h3>
+        <table id="sellHoldingsTable"></table>
+      </div>
+
+      <div id="tradeForm" class="hidden">
+        <label for="tradeSymbol">Symbol</label><br/>
+        <select id="tradeSymbol"></select><br/>
+        <div id="analysisPanel" class="hidden">
+          <div id="metrics">
+            <div>Price: $<span id="price">0</span></div>
+            <div>Volatility: <span id="volatility">0</span></div>
+            <div>Average: $<span id="average">0</span></div>
+            <div>High: $<span id="high">0</span></div>
+            <div>Low: $<span id="low">0</span></div>
+          </div>
+          <div class="chart-wrapper">
+            <div id="companyChart"></div>
+          </div>
+          <p class="analysis-note">Options prices are calculated using the Black-Scholes model.</p>
+        </div>
+        <div>Price: $<span id="tradePrice">0.00</span></div>
+        <label for="tradeQty">Quantity</label><br/>
+        <input id="tradeQty" type="number" min="1" value="1" /><br/>
+        <input id="tradeQtySlider" type="range" min="1" value="1" /><br/>
+        <div><span id="tradeTotalLabel">Total Cost:</span> $<span id="tradeTotal">0.00</span></div>
+        <button type="button" id="buyBtn">Execute Order</button>
+        <button type="button" id="sellBtn">Execute Order</button>
+        <button type="button" id="cancelTradeBtn">Cancel</button>
+      </div>
+
+      
+    <div id="tradeConfirm" class="confirm-message"></div>
+    <table id="tradeHistoryTable"></table>
+    <div class="analysis-nav">
+      <button type="button" onclick="location.href='play.html'">Back</button>
+    </div>
+  </div>
+  <script src="js/storage.js"></script>
+  <script src="js/player.js"></script>
+  <script src="js/dialog.js"></script>
+  <script src="js/trade.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- split combined trade page into `trade-stocks.html` and `trade-options.html`
- use CSS variables to support page-specific color themes
- add amber theme for options page via `body.amber`
- update game menu to link to the new trade pages
- adjust `trade.js` to work with either trading page

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_686fb5ec96188325a64d1eec6dd522c6