### PR TITLE
Restrict stock options until apprentice

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -175,6 +175,7 @@ function startGame() {
   }
   displayUsername();
   updateStatus();
+  updateOptionsAccess();
   initMarketHistory();
   renderMarketChart();
   renderNews();
@@ -206,6 +207,16 @@ function displayUsername() {
   }
 }
 
+function updateOptionsAccess() {
+  const btn = document.getElementById('tradeOptionsBtn');
+  if (!btn) return;
+  if (gameState.rank === 'Novice') {
+    btn.classList.add('hidden');
+  } else {
+    btn.classList.remove('hidden');
+  }
+}
+
 function updateRank() {
   const prev = gameState.rank;
   const worth = gameState.netWorth;
@@ -225,6 +236,7 @@ function updateRank() {
     setApprenticeSeen();
     window.location.href = 'apprentice.html';
   }
+  updateOptionsAccess();
 }
 
 function showGameOverDialog() {

--- a/docs/play.html
+++ b/docs/play.html
@@ -25,7 +25,7 @@
   <div class="menu">
     <button id="doneBtn" class="advance">Advance to Next Week</button>
     <button id="tradeStocksBtn" onclick="location.href='trade-stocks.html'">Trade Stocks</button>
-    <button id="tradeOptionsBtn" onclick="location.href='trade-options.html'">Trade Stock Options</button>
+    <button id="tradeOptionsBtn" class="hidden" onclick="location.href='trade-options.html'">Trade Stock Options</button>
     <button id="portfolioBtn">Portfolio</button>
     <button id="cashOutBtn">Retire</button>
   </div>

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -60,6 +60,12 @@
     </div>
   </div>
   <script src="js/storage.js"></script>
+  <script>
+    const state = loadState();
+    if (!state || state.rank === 'Novice') {
+      window.location.href = 'play.html';
+    }
+  </script>
   <script src="js/options.js"></script>
   <script src="js/player.js"></script>
   <script src="js/dialog.js"></script>


### PR DESCRIPTION
## Summary
- hide the Trade Stock Options button until a player reaches apprentice
- update game logic to control visibility for the options button
- block direct access to the trade options page for novices

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_686fd10961b48325894eac1b9ec9c988