### PR TITLE
Enable options trading after Apprentice rank

### DIFF
--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -210,10 +210,12 @@ function displayUsername() {
 function updateOptionsAccess() {
   const btn = document.getElementById('tradeOptionsBtn');
   if (!btn) return;
-  if (gameState.rank === 'Novice') {
-    btn.classList.add('hidden');
-  } else {
+  const unlocked = gameState.rank !== 'Novice' ||
+                   (typeof hasSeenApprentice === 'function' && hasSeenApprentice());
+  if (unlocked) {
     btn.classList.remove('hidden');
+  } else {
+    btn.classList.add('hidden');
   }
 }
 

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -550,7 +550,9 @@ document.addEventListener('DOMContentLoaded', () => {
       renderMetrics();
       renderTradeHistory();
       const optForm = document.getElementById('optionsForm');
-      if (gameState.rank !== 'Novice' && optForm) {
+      const unlocked = gameState.rank !== 'Novice' ||
+                       (typeof hasSeenApprentice === 'function' && hasSeenApprentice());
+      if (unlocked && optForm) {
         populateOptionSymbols(companies.filter(c => !c.isIndex));
         populateOptionDetails();
         optForm.classList.remove('hidden');
@@ -582,7 +584,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const cancelTradeBtn = document.getElementById('cancelTradeBtn');
   if (cancelTradeBtn) cancelTradeBtn.addEventListener('click', hideOrderForm);
 
-  if (gameState.rank !== 'Novice') {
+  const unlocked = gameState.rank !== 'Novice' ||
+                   (typeof hasSeenApprentice === 'function' && hasSeenApprentice());
+  if (unlocked) {
     const optSymbol = document.getElementById('optSymbol');
     if (optSymbol) optSymbol.addEventListener('change', () => {
       populateOptionDetails();

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -62,7 +62,8 @@
   <script src="js/storage.js"></script>
   <script>
     const state = loadState();
-    if (!state || state.rank === 'Novice') {
+    const apprentice = typeof hasSeenApprentice === 'function' && hasSeenApprentice();
+    if (!state || (state.rank === 'Novice' && !apprentice)) {
       window.location.href = 'play.html';
     }
   </script>


### PR DESCRIPTION
## Summary
- persist options trading unlock after reaching Apprentice
- allow visiting options page once Apprentice is unlocked
- gate trade page option controls by Apprentice unlock

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_686fd3589e248325a62c864bab1c84d9