### PR TITLE
Update options page header and chart colors

### DIFF
--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -270,6 +270,7 @@ function computeAverage(prices) {
 }
 
 function drawChart(history) {
+  const accentColor = getComputedStyle(document.body).getPropertyValue('--accent-color').trim() || '#39ff14';
   currentHistory = history;
   const container = d3.select('#companyChart');
   if (container.empty()) return;
@@ -313,7 +314,7 @@ function drawChart(history) {
   const pricePath = plot.append('path')
     .datum(history)
     .attr('fill', 'none')
-    .attr('stroke', '#39ff14')
+    .attr('stroke', accentColor)
     .attr('stroke-width', 2)
     .attr('d', line);
 
@@ -328,7 +329,7 @@ function drawChart(history) {
     .attr('x', chartWidth / 2)
     .attr('y', chartHeight + margin.bottom - 5)
     .attr('text-anchor', 'middle')
-    .attr('fill', '#33ff33')
+    .attr('fill', accentColor)
     .text('Week');
 
   const zoom = d3.zoom()

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -9,7 +9,7 @@
 </head>
 <body class="amber">
   <div class="trade-container">
-    <h1>Trade</h1>
+    <h1>Trade Stock Options</h1>
     <table class="metrics-table">
       <tr><th>Worth</th><td>$<span id="tNetWorth">0</span></td></tr>
       <tr><th>Cash</th><td>$<span id="tCash">0</span></td></tr>


### PR DESCRIPTION
## Summary
- update the heading on `trade-options.html`
- use the accent color for the price curve and x-axis label

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_68713821b21c8325967e9a7c3e3f3532