### PR TITLE
Improve stock trade page header and history

### DIFF
--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -18,7 +18,11 @@ function renderTradeHistory() {
   const header = document.createElement('tr');
   header.innerHTML = '<th>Week</th><th>Type</th><th>Symbol</th><th>Qty</th><th>Price</th><th>Commission</th><th>Fees</th><th>Total</th>';
   tbl.appendChild(header);
-  (gameState.tradeHistory || []).forEach(t => {
+  let history = gameState.tradeHistory || [];
+  if (window.stockTradeHistoryOnly) {
+    history = history.filter(t => t.type === 'BUY' || t.type === 'SELL');
+  }
+  history.forEach(t => {
     const row = document.createElement('tr');
     row.innerHTML = `<td>${t.week}</td><td>${t.type}</td><td>${t.symbol}</td><td>${t.qty}</td><td>$${t.price.toFixed(2)}</td><td>$${t.commission.toFixed(2)}</td><td>$${t.fees.toFixed(2)}</td><td>$${t.total.toFixed(2)}</td>`;
     tbl.appendChild(row);

--- a/docs/trade-stocks.html
+++ b/docs/trade-stocks.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <div class="trade-container">
-    <h1>Trade</h1>
+    <h1>Trade Stocks</h1>
     <table class="metrics-table">
       <tr><th>Worth</th><td>$<span id="tNetWorth">0</span></td></tr>
       <tr><th>Cash</th><td>$<span id="tCash">0</span></td></tr>
@@ -60,6 +60,7 @@
   <script src="js/storage.js"></script>
   <script src="js/player.js"></script>
   <script src="js/dialog.js"></script>
+  <script>window.stockTradeHistoryOnly = true;</script>
   <script src="js/trade.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- clarify stock trading page header
- add variable to filter stock trades
- show only stock trade history on the stock trade page

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_68713f791d588325b32522a471309208