### PR TITLE
Fix trade history on options page

### DIFF
--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -21,6 +21,8 @@ function renderTradeHistory() {
   let history = gameState.tradeHistory || [];
   if (window.stockTradeHistoryOnly) {
     history = history.filter(t => t.type === 'BUY' || t.type === 'SELL');
+  } else if (window.optionsTradeHistoryOnly) {
+    history = history.filter(t => t.type !== 'BUY' && t.type !== 'SELL');
   }
   history.forEach(t => {
     const row = document.createElement('tr');

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -70,6 +70,7 @@
   <script src="js/options.js"></script>
   <script src="js/player.js"></script>
   <script src="js/dialog.js"></script>
+  <script>window.optionsTradeHistoryOnly = true;</script>
   <script src="js/trade.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- filter out stock trades when viewing the options trading page
- enable the filter on the options trading page

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_687141d901608325a6f69c8b33fa58fd