### PR TITLE
Remove donation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,4 @@ This is a personal software project. It is **not** financial advice, an investme
 MIT License. Do what you want, but don’t blame me when your portfolio goes to zero.
 
 ---
-
-## Support
-
-If Drawdown has entertained you, consider [buying me a coffee](https://coff.ee/stevedrasco). Even a small donation helps keep the caffeine flowing during those inevitable drawdowns.
-
----
-
 © 2025 Steve Drasco · steve.drasco@gmail.com

--- a/docs/high-scores.html
+++ b/docs/high-scores.html
@@ -53,7 +53,6 @@
   <h1>High Scores</h1>
   <table id="scoresTable"></table>
   <p><a href="index.html">Back</a></p>
-  <a class="link-wrapper" href="https://coff.ee/stevedrasco" target="_blank">Coffee for Drawdowns</a>
   <script type="module">
     import { initScores, loadBoard, watchBoard } from './js/highscores.js';
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -127,9 +127,6 @@
       <a class="link-wrapper" href="https://github.com/sdrasco/drawdowngame/blob/main/README.md" target="_blank">
         About
       </a>
-      <a class="link-wrapper" href="https://coff.ee/stevedrasco" target="_blank">
-        Coffee for Drawdowns
-      </a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- delete "Coffee for Drawdowns" buttons from docs
- drop coffee donation section from README

## Testing
- `node tests/test_player.js`


------
https://chatgpt.com/codex/tasks/task_e_68715ba9341883258d2ce61d7a3ce787