### PR TITLE
Implement popup for selling options

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -305,6 +305,12 @@ select {
   touch-action: none;
 }
 
+#sellOptionQtySlider {
+  width: 100%;
+  accent-color: var(--accent-color);
+  touch-action: none;
+}
+
 .portfolio-container {
   max-width: 600px;
   margin: 0 auto;

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -509,6 +509,55 @@ function doBuyOption() {
   renderSellOptions();
 }
 
+function showOptionSellPopup() {
+  const popup = document.getElementById('optionSellPopup');
+  if (!popup) return;
+  const select = document.getElementById('sellOptionSelect');
+  select.innerHTML = '';
+  (gameState.options || []).forEach((opt, idx) => {
+    const remaining = opt.weeksToExpiry - (gameState.week - opt.purchaseWeek);
+    if (remaining <= 0) return;
+    const o = document.createElement('option');
+    o.value = idx;
+    o.textContent = `${opt.symbol} ${opt.type} ${opt.strike} (qty ${opt.qty})`;
+    select.appendChild(o);
+  });
+  updateSellOptionQty();
+  popup.classList.remove('hidden');
+}
+
+function hideOptionSellPopup() {
+  const popup = document.getElementById('optionSellPopup');
+  if (popup) popup.classList.add('hidden');
+}
+
+function updateSellOptionQty() {
+  const select = document.getElementById('sellOptionSelect');
+  const slider = document.getElementById('sellOptionQtySlider');
+  const label = document.getElementById('sellOptionQtyLabel');
+  const idx = parseInt(select.value, 10) || 0;
+  const opt = (gameState.options || [])[idx];
+  const max = opt ? opt.qty : 1;
+  slider.max = max;
+  slider.value = 1;
+  if (label) label.textContent = '1';
+}
+
+function confirmSellOption() {
+  const select = document.getElementById('sellOptionSelect');
+  const slider = document.getElementById('sellOptionQtySlider');
+  const idx = parseInt(select.value, 10) || 0;
+  const qty = parseInt(slider.value, 10) || 1;
+  const optPos = (gameState.options || [])[idx];
+  if (!optPos || qty <= 0) { hideOptionSellPopup(); return; }
+  document.getElementById('optSymbol').value = optPos.symbol;
+  document.getElementById('optType').value = optPos.type;
+  document.getElementById('optStrike').value = optPos.strike;
+  document.getElementById('optQty').value = qty;
+  hideOptionSellPopup();
+  doSellOption();
+}
+
 function doSellOption() {
   const sym = document.getElementById('optSymbol').value.trim().toUpperCase();
   const type = document.getElementById('optType').value;
@@ -610,7 +659,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const optBuyBtn = document.getElementById('optBuyBtn');
     if (optBuyBtn) optBuyBtn.addEventListener('click', doBuyOption);
     const optSellBtn = document.getElementById('optSellBtn');
-    if (optSellBtn) optSellBtn.addEventListener('click', doSellOption);
+    if (optSellBtn) optSellBtn.addEventListener('click', showOptionSellPopup);
+    const sellSelect = document.getElementById('sellOptionSelect');
+    if (sellSelect) sellSelect.addEventListener('change', updateSellOptionQty);
+    const sellSlider = document.getElementById('sellOptionQtySlider');
+    if (sellSlider) sellSlider.addEventListener('input', e => {
+      const lbl = document.getElementById('sellOptionQtyLabel');
+      if (lbl) lbl.textContent = e.target.value;
+    });
+    const sellConfirm = document.getElementById('sellOptionConfirm');
+    if (sellConfirm) sellConfirm.addEventListener('click', confirmSellOption);
+    const sellCancel = document.getElementById('sellOptionCancel');
+    if (sellCancel) sellCancel.addEventListener('click', hideOptionSellPopup);
   }
 });
 

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -53,6 +53,16 @@
         <h3>Your Options</h3>
         <table id="sellOptionsTable"></table>
       </div>
+      <div id="optionSellPopup" class="username-prompt hidden">
+        <form>
+          <label for="sellOptionSelect">Select Option</label><br/>
+          <select id="sellOptionSelect"></select><br/>
+          <label for="sellOptionQtySlider">Contracts to Sell: <span id="sellOptionQtyLabel">1</span></label><br/>
+          <input id="sellOptionQtySlider" type="range" min="1" value="1" /><br/>
+          <button type="button" id="sellOptionConfirm">Sell</button>
+          <button type="button" id="sellOptionCancel">Cancel</button>
+        </form>
+      </div>
     <div id="tradeConfirm" class="confirm-message"></div>
     <table id="tradeHistoryTable"></table>
     <div class="analysis-nav">


### PR DESCRIPTION
## Summary
- add an overlay popup on the options trading page to sell owned options
- style slider for selecting option quantity
- wire up popup logic in trade.js

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_687168ec8ce88325a8c385df5b13e382