### PR TITLE
Update options selling flow

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,4 +1,6 @@
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
 :root {
   --accent-color: #33ff33;
@@ -14,12 +16,13 @@ body.amber,
 body {
   background: #000;
   color: var(--accent-color);
-  font-family: 'Courier New', Courier, monospace;
+  font-family: "Courier New", Courier, monospace;
   margin: 0;
   padding: 2rem;
 }
 
-input, button {
+input,
+button {
   font-family: inherit;
   font-size: 1rem;
   padding: 0.5rem;
@@ -75,7 +78,6 @@ button:hover {
 .section {
   margin-bottom: 1.5rem;
 }
-
 
 .status {
   display: grid;
@@ -189,7 +191,7 @@ button:hover {
 }
 
 .news .headline::before {
-  content: '\25ba';
+  content: "\25ba";
   position: absolute;
   left: 0;
   color: var(--accent-color);
@@ -284,8 +286,9 @@ select {
 #tradeHistoryTable {
   margin: 1rem auto;
   border-collapse: collapse;
-  width: 100%;
+  width: auto;
   max-width: 400px;
+  text-align: center;
 }
 
 #tradeHistoryTable th,
@@ -344,4 +347,3 @@ select {
   margin: 0 auto;
   text-align: center;
 }
-

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -1,40 +1,47 @@
 let companies = [];
 let gameState;
-let tradeMode = 'BUY';
+let tradeMode = "BUY";
 
 let currentHistory = [];
 
 function renderMetrics() {
   if (!gameState) return;
   computeNetWorth(gameState);
-  document.getElementById('tNetWorth').textContent = Math.round(gameState.netWorth).toLocaleString();
-  document.getElementById('tCash').textContent = Math.round(gameState.cash).toLocaleString();
+  document.getElementById("tNetWorth").textContent = Math.round(
+    gameState.netWorth,
+  ).toLocaleString();
+  document.getElementById("tCash").textContent = Math.round(
+    gameState.cash,
+  ).toLocaleString();
 }
 
 function renderTradeHistory() {
-  const tbl = document.getElementById('tradeHistoryTable');
+  const tbl = document.getElementById("tradeHistoryTable");
   if (!tbl) return;
-  tbl.innerHTML = '';
-  const header = document.createElement('tr');
+  tbl.innerHTML = "";
+  const header = document.createElement("tr");
   if (window.optionsTradeHistoryOnly) {
-    header.innerHTML = '<th>Week</th><th>Action</th><th>Symbol</th><th>Type</th><th>Strike</th><th>Weeks</th><th>Qty</th><th>Price</th><th>Commission</th><th>Fees</th><th>Total</th>';
+    header.innerHTML =
+      "<th>Week</th><th>Action</th><th>Symbol</th><th>Type</th><th>Strike</th><th>Weeks</th><th>Qty</th><th>Price</th><th>Commission</th><th>Fees</th><th>Total</th>";
   } else {
-    header.innerHTML = '<th>Week</th><th>Type</th><th>Symbol</th><th>Qty</th><th>Price</th><th>Commission</th><th>Fees</th><th>Total</th>';
+    header.innerHTML =
+      "<th>Week</th><th>Type</th><th>Symbol</th><th>Qty</th><th>Price</th><th>Commission</th><th>Fees</th><th>Total</th>";
   }
   tbl.appendChild(header);
   let history = gameState.tradeHistory || [];
   if (window.stockTradeHistoryOnly) {
-    history = history.filter(t => t.type === 'BUY' || t.type === 'SELL');
+    history = history.filter((t) => t.type === "BUY" || t.type === "SELL");
   } else if (window.optionsTradeHistoryOnly) {
-    history = history.filter(t => t.type !== 'BUY' && t.type !== 'SELL');
+    history = history.filter((t) => t.type !== "BUY" && t.type !== "SELL");
   }
-  history.forEach(t => {
-    const row = document.createElement('tr');
+  history.forEach((t) => {
+    const row = document.createElement("tr");
     if (window.optionsTradeHistoryOnly) {
-      const act = t.type.startsWith('BUY') ? 'BUY' : 'SELL';
-      const optType = t.optionType || (t.type.includes('CALL') ? 'call' : 'put');
-      const strike = t.strike !== undefined ? t.strike : '';
-      const weeks = t.weeks !== undefined ? t.weeks : '';
+      const act = t.type.startsWith("BUY") ? "BUY" : "SELL";
+      const optType =
+        t.optionType || (t.type.includes("CALL") ? "call" : "put");
+      const strike = t.strike !== undefined ? t.strike : "";
+      const weeks = t.weeks !== undefined ? t.weeks : "";
       row.innerHTML = `<td>${t.week}</td><td>${act}</td><td>${t.symbol}</td><td>${optType}</td><td>${strike}</td><td>${weeks}</td><td>${t.qty}</td><td>$${t.price.toFixed(2)}</td><td>$${t.commission.toFixed(2)}</td><td>$${t.fees.toFixed(2)}</td><td>$${t.total.toFixed(2)}</td>`;
     } else {
       row.innerHTML = `<td>${t.week}</td><td>${t.type}</td><td>${t.symbol}</td><td>${t.qty}</td><td>$${t.price.toFixed(2)}</td><td>$${t.commission.toFixed(2)}</td><td>$${t.fees.toFixed(2)}</td><td>$${t.total.toFixed(2)}</td>`;
@@ -44,42 +51,46 @@ function renderTradeHistory() {
 }
 
 function showTradeDialog(trade) {
-  const totalLabel = (trade.type && trade.type.startsWith('BUY')) ?
-                     'Total Cost' : 'Net Proceeds';
-  const msg = `${trade.type} ${trade.qty} ${trade.symbol} @ $${trade.price.toFixed(2)}<br/>` +
+  const totalLabel =
+    trade.type && trade.type.startsWith("BUY") ? "Total Cost" : "Net Proceeds";
+  const msg =
+    `${trade.type} ${trade.qty} ${trade.symbol} @ $${trade.price.toFixed(2)}<br/>` +
     `Commission: $${trade.commission.toFixed(2)}<br/>Fees: $${trade.fees.toFixed(2)}<br/>` +
     `${totalLabel}: $${trade.total.toFixed(2)}`;
-  if (typeof showMessage === 'function') {
+  if (typeof showMessage === "function") {
     showMessage(msg);
   }
 }
 
 function populateTradeSymbols(list) {
-  const select = document.getElementById('tradeSymbol');
+  const select = document.getElementById("tradeSymbol");
   if (!select) return;
-  select.innerHTML = '';
-  list.slice().sort((a, b) => a.symbol.localeCompare(b.symbol)).forEach(c => {
-    const opt = document.createElement('option');
-    opt.value = c.symbol;
-    opt.textContent = `${c.symbol} - ${c.name}`;
-    select.appendChild(opt);
-  });
+  select.innerHTML = "";
+  list
+    .slice()
+    .sort((a, b) => a.symbol.localeCompare(b.symbol))
+    .forEach((c) => {
+      const opt = document.createElement("option");
+      opt.value = c.symbol;
+      opt.textContent = `${c.symbol} - ${c.name}`;
+      select.appendChild(opt);
+    });
 }
 
 function getHoldingsList() {
   const symbols = Object.keys(gameState.positions || {});
-  return companies.filter(c => symbols.includes(c.symbol));
+  return companies.filter((c) => symbols.includes(c.symbol));
 }
 
 function renderSellHoldings() {
-  const tbl = document.getElementById('sellHoldingsTable');
+  const tbl = document.getElementById("sellHoldingsTable");
   if (!tbl) return;
-  tbl.innerHTML = '';
-  const header = document.createElement('tr');
-  header.innerHTML = '<th>Symbol</th><th>Qty</th>';
+  tbl.innerHTML = "";
+  const header = document.createElement("tr");
+  header.innerHTML = "<th>Symbol</th><th>Qty</th>";
   tbl.appendChild(header);
-  Object.keys(gameState.positions || {}).forEach(sym => {
-    const row = document.createElement('tr');
+  Object.keys(gameState.positions || {}).forEach((sym) => {
+    const row = document.createElement("tr");
     const qty = gameState.positions[sym].qty;
     row.innerHTML = `<td>${sym}</td><td>${qty}</td>`;
     tbl.appendChild(row);
@@ -87,69 +98,79 @@ function renderSellHoldings() {
 }
 
 function renderSellOptions() {
-  const tbl = document.getElementById('sellOptionsTable');
+  const tbl = document.getElementById("sellOptionsTable");
   if (!tbl) return;
-  tbl.innerHTML = '';
-  const header = document.createElement('tr');
-  header.innerHTML = '<th>Symbol</th><th>Type</th><th>Strike</th><th>Qty</th><th>Value</th><th>Weeks Left</th><th></th>';
+  tbl.innerHTML = "";
+  const header = document.createElement("tr");
+  header.innerHTML =
+    "<th>Symbol</th><th>Type</th><th>Strike</th><th>Qty</th><th>Value</th><th>Weeks Left</th><th>Action</th>";
   tbl.appendChild(header);
-  populateSellOptionSelect();
   (gameState.options || []).forEach((opt, idx) => {
     const remaining = opt.weeksToExpiry - (gameState.week - opt.purchaseWeek);
     if (remaining <= 0) return;
     const weeks = gameState.prices[opt.symbol];
     if (!weeks || !bsPrice) return;
     const price = weeks[weeks.length - 1][weeks[weeks.length - 1].length - 1];
-    const val = bsPrice(price, opt.strike, OPTION_RISK_FREE_RATE, OPTION_VOLATILITY, remaining / 52, opt.type) * opt.qty;
-    const row = document.createElement('tr');
+    const val =
+      bsPrice(
+        price,
+        opt.strike,
+        OPTION_RISK_FREE_RATE,
+        OPTION_VOLATILITY,
+        remaining / 52,
+        opt.type,
+      ) * opt.qty;
+    const row = document.createElement("tr");
     row.innerHTML = `<td>${opt.symbol}</td><td>${opt.type}</td><td>${opt.strike}</td><td>${opt.qty}</td><td>$${val.toFixed(2)}</td><td>${remaining}</td>`;
-    const btnCell = document.createElement('td');
-    const btn = document.createElement('button');
-    btn.textContent = 'Sell';
-    btn.addEventListener('click', () => selectOptionForSell(idx));
+    const btnCell = document.createElement("td");
+    const btn = document.createElement("button");
+    btn.textContent = "Close Position";
+    btn.addEventListener("click", () => closeOptionPosition(idx));
     btnCell.appendChild(btn);
     row.appendChild(btnCell);
     tbl.appendChild(row);
   });
 }
 
-
 function populateOptionSymbols(list) {
-  const select = document.getElementById('optSymbol');
+  const select = document.getElementById("optSymbol");
   if (!select) return;
-  select.innerHTML = '';
-  list.slice().sort((a, b) => a.symbol.localeCompare(b.symbol)).forEach(c => {
-    const opt = document.createElement('option');
-    opt.value = c.symbol;
-    opt.textContent = `${c.symbol} - ${c.name}`;
-    select.appendChild(opt);
-  });
+  select.innerHTML = "";
+  list
+    .slice()
+    .sort((a, b) => a.symbol.localeCompare(b.symbol))
+    .forEach((c) => {
+      const opt = document.createElement("option");
+      opt.value = c.symbol;
+      opt.textContent = `${c.symbol} - ${c.name}`;
+      select.appendChild(opt);
+    });
 }
 
 function populateOptionDetails() {
-  const sym = document.getElementById('optSymbol').value;
+  const sym = document.getElementById("optSymbol").value;
   const weeksArr = gameState.prices[sym];
   if (!weeksArr) return;
   const week = weeksArr[weeksArr.length - 1];
   const price = week[week.length - 1];
 
-  document.getElementById('optStockPrice').textContent = price.toFixed(2);
+  document.getElementById("optStockPrice").textContent = price.toFixed(2);
 
-  const strikeSelect = document.getElementById('optStrike');
-  strikeSelect.innerHTML = '';
+  const strikeSelect = document.getElementById("optStrike");
+  strikeSelect.innerHTML = "";
   const deltas = [-0.2, -0.1, 0, 0.1, 0.2];
-  deltas.forEach(d => {
+  deltas.forEach((d) => {
     const strike = Math.round((price * (1 + d)) / 5) * 5;
-    const opt = document.createElement('option');
+    const opt = document.createElement("option");
     opt.value = strike.toFixed(2);
     opt.textContent = strike.toFixed(2);
     strikeSelect.appendChild(opt);
   });
 
-  const weeksSelect = document.getElementById('optWeeks');
-  weeksSelect.innerHTML = '';
-  [4, 8, 12, 16].forEach(w => {
-    const opt = document.createElement('option');
+  const weeksSelect = document.getElementById("optWeeks");
+  weeksSelect.innerHTML = "";
+  [4, 8, 12, 16].forEach((w) => {
+    const opt = document.createElement("option");
     opt.value = w;
     opt.textContent = w;
     weeksSelect.appendChild(opt);
@@ -157,67 +178,80 @@ function populateOptionDetails() {
 }
 
 function updateOptionInfo() {
-  const sym = document.getElementById('optSymbol').value;
-  const strike = parseFloat(document.getElementById('optStrike').value) || 0;
-  const weeks = parseInt(document.getElementById('optWeeks').value, 10) || 0;
-  const qty = parseInt(document.getElementById('optQty').value, 10) || 0;
-  const type = document.getElementById('optType').value;
+  const sym = document.getElementById("optSymbol").value;
+  const strike = parseFloat(document.getElementById("optStrike").value) || 0;
+  const weeks = parseInt(document.getElementById("optWeeks").value, 10) || 0;
+  const qty = parseInt(document.getElementById("optQty").value, 10) || 0;
+  const type = document.getElementById("optType").value;
   const weeksArr = gameState.prices[sym];
   if (!weeksArr || !bsPrice) return;
   const week = weeksArr[weeksArr.length - 1];
   const S = week[week.length - 1];
-  document.getElementById('optStockPrice').textContent = S.toFixed(2);
-  const premium = bsPrice(S, strike, OPTION_RISK_FREE_RATE, OPTION_VOLATILITY,
-                         weeks / 52, type);
-  document.getElementById('optPremium').textContent = premium.toFixed(2);
+  document.getElementById("optStockPrice").textContent = S.toFixed(2);
+  const premium = bsPrice(
+    S,
+    strike,
+    OPTION_RISK_FREE_RATE,
+    OPTION_VOLATILITY,
+    weeks / 52,
+    type,
+  );
+  document.getElementById("optPremium").textContent = premium.toFixed(2);
   const tradeValue = premium * qty;
   const commission = TRADE_COMMISSION;
   const fees = +(tradeValue * TRADE_FEE_RATE).toFixed(2);
-  document.getElementById('optTotal').textContent = (tradeValue + commission + fees).toFixed(2);
+  document.getElementById("optTotal").textContent = (
+    tradeValue +
+    commission +
+    fees
+  ).toFixed(2);
   updateAnalysisPanel();
 }
 
 function showOrderForm(mode) {
   tradeMode = mode;
-  document.getElementById('tradeModeSelect').classList.add('hidden');
-  document.getElementById('tradeForm').classList.remove('hidden');
-  document.getElementById('analysisPanel').classList.remove('hidden');
-  document.getElementById('buyBtn').classList.toggle('hidden', mode !== 'BUY');
-  document.getElementById('sellBtn').classList.toggle('hidden', mode !== 'SELL');
-  const holdingsDiv = document.getElementById('sellHoldings');
-  if (mode === 'SELL') {
-    holdingsDiv.classList.remove('hidden');
+  document.getElementById("tradeModeSelect").classList.add("hidden");
+  document.getElementById("tradeForm").classList.remove("hidden");
+  document.getElementById("analysisPanel").classList.remove("hidden");
+  document.getElementById("buyBtn").classList.toggle("hidden", mode !== "BUY");
+  document
+    .getElementById("sellBtn")
+    .classList.toggle("hidden", mode !== "SELL");
+  const holdingsDiv = document.getElementById("sellHoldings");
+  if (mode === "SELL") {
+    holdingsDiv.classList.remove("hidden");
     renderSellHoldings();
     populateTradeSymbols(getHoldingsList());
   } else {
-    holdingsDiv.classList.add('hidden');
-    populateTradeSymbols(companies.filter(c => !c.isIndex));
+    holdingsDiv.classList.add("hidden");
+    populateTradeSymbols(companies.filter((c) => !c.isIndex));
   }
   updateTradeInfo();
   updateAnalysisPanel();
 }
 
 function hideOrderForm() {
-  document.getElementById('tradeForm').classList.add('hidden');
-  document.getElementById('sellHoldings').classList.add('hidden');
-  document.getElementById('tradeModeSelect').classList.remove('hidden');
-  document.getElementById('analysisPanel').classList.add('hidden');
+  document.getElementById("tradeForm").classList.add("hidden");
+  document.getElementById("sellHoldings").classList.add("hidden");
+  document.getElementById("tradeModeSelect").classList.remove("hidden");
+  document.getElementById("analysisPanel").classList.add("hidden");
 }
 
 function updateTradeInfo() {
-  const sym = document.getElementById('tradeSymbol').value;
+  const sym = document.getElementById("tradeSymbol").value;
   const weeks = gameState.prices[sym];
   if (!weeks) return;
   const week = weeks[weeks.length - 1];
   const price = week[week.length - 1];
-  document.getElementById('tradePrice').textContent = price.toFixed(2);
+  document.getElementById("tradePrice").textContent = price.toFixed(2);
 
-  const slider = document.getElementById('tradeQtySlider');
-  const input = document.getElementById('tradeQty');
+  const slider = document.getElementById("tradeQtySlider");
+  const input = document.getElementById("tradeQty");
   const maxBuy = calculateMaxBuy(gameState.cash, price);
-  const holdings = (gameState.positions[sym] && gameState.positions[sym].qty) || 0;
+  const holdings =
+    (gameState.positions[sym] && gameState.positions[sym].qty) || 0;
   let max;
-  if (tradeMode === 'SELL') {
+  if (tradeMode === "SELL") {
     max = Math.max(holdings, 1);
   } else {
     max = Math.max(maxBuy, 1);
@@ -230,21 +264,22 @@ function updateTradeInfo() {
 }
 
 function updateTradeTotal() {
-  const qty = parseInt(document.getElementById('tradeQty').value, 10) || 0;
-  const price = parseFloat(document.getElementById('tradePrice').textContent) || 0;
+  const qty = parseInt(document.getElementById("tradeQty").value, 10) || 0;
+  const price =
+    parseFloat(document.getElementById("tradePrice").textContent) || 0;
   const tradeValue = qty * price;
   const commission = TRADE_COMMISSION;
   const fees = +(tradeValue * TRADE_FEE_RATE).toFixed(2);
   let total;
-  const label = document.getElementById('tradeTotalLabel');
-  if (tradeMode === 'SELL') {
+  const label = document.getElementById("tradeTotalLabel");
+  if (tradeMode === "SELL") {
     total = tradeValue - commission - fees;
-    if (label) label.textContent = 'Net Proceeds:';
+    if (label) label.textContent = "Net Proceeds:";
   } else {
     total = tradeValue + commission + fees;
-    if (label) label.textContent = 'Total Cost:';
+    if (label) label.textContent = "Total Cost:";
   }
-  const span = document.getElementById('tradeTotal');
+  const span = document.getElementById("tradeTotal");
   if (span) span.textContent = total.toFixed(2);
 }
 
@@ -265,73 +300,91 @@ function computeAverage(prices) {
 }
 
 function drawChart(history) {
-  const accentColor = getComputedStyle(document.body).getPropertyValue('--accent-color').trim() || '#39ff14';
+  const accentColor =
+    getComputedStyle(document.body).getPropertyValue("--accent-color").trim() ||
+    "#39ff14";
   currentHistory = history;
-  const container = d3.select('#companyChart');
+  const container = d3.select("#companyChart");
   if (container.empty()) return;
-  container.selectAll('*').remove();
+  container.selectAll("*").remove();
   if (history.length === 0) return;
   const width = container.node().clientWidth;
-  const height = width * 350 / 600;
+  const height = (width * 350) / 600;
   const margin = { top: 20, right: 20, bottom: 40, left: 40 };
-  const svg = container.append('svg')
-    .attr('width', width)
-    .attr('height', height);
+  const svg = container
+    .append("svg")
+    .attr("width", width)
+    .attr("height", height);
   const chartWidth = width - margin.left - margin.right;
   const chartHeight = height - margin.top - margin.bottom;
-  const g = svg.append('g')
-    .attr('transform', `translate(${margin.left},${margin.top})`);
+  const g = svg
+    .append("g")
+    .attr("transform", `translate(${margin.left},${margin.top})`);
   const weeks = history.map((_, i) => i + 1);
-  const x = d3.scaleLinear()
-    .domain(d3.extent(weeks))
-    .range([0, chartWidth]);
-  const y = d3.scaleLinear()
+  const x = d3.scaleLinear().domain(d3.extent(weeks)).range([0, chartWidth]);
+  const y = d3
+    .scaleLinear()
     .domain([d3.min(history), d3.max(history)])
     .nice()
     .range([chartHeight, 0]);
-  const line = d3.line()
+  const line = d3
+    .line()
     .x((d, i) => x(weeks[i]))
-    .y(d => y(d))
+    .y((d) => y(d))
     .curve(d3.curveMonotoneX);
 
-  svg.style('touch-action', 'none');
+  svg.style("touch-action", "none");
 
-  const clipId = 'clip-companyChart';
-  svg.append('defs').append('clipPath')
-    .attr('id', clipId)
-    .append('rect')
-    .attr('width', chartWidth)
-    .attr('height', chartHeight);
+  const clipId = "clip-companyChart";
+  svg
+    .append("defs")
+    .append("clipPath")
+    .attr("id", clipId)
+    .append("rect")
+    .attr("width", chartWidth)
+    .attr("height", chartHeight);
 
-  const plot = g.append('g')
-    .attr('clip-path', `url(#${clipId})`);
+  const plot = g.append("g").attr("clip-path", `url(#${clipId})`);
 
-  const pricePath = plot.append('path')
+  const pricePath = plot
+    .append("path")
     .datum(history)
-    .attr('fill', 'none')
-    .attr('stroke', accentColor)
-    .attr('stroke-width', 2)
-    .attr('d', line);
+    .attr("fill", "none")
+    .attr("stroke", accentColor)
+    .attr("stroke-width", 2)
+    .attr("d", line);
 
-  const xAxis = g.append('g')
-    .attr('transform', `translate(0,${chartHeight})`)
+  const xAxis = g
+    .append("g")
+    .attr("transform", `translate(0,${chartHeight})`)
     .call(d3.axisBottom(x).ticks(10));
-  const yAxis = g.append('g')
-    .call(d3.axisLeft(y).ticks(5).tickFormat(d => {
-      return Math.abs(d) >= 1000 ? Math.round(d / 1000) + 'k' : d;
-    }));
-  g.append('text')
-    .attr('x', chartWidth / 2)
-    .attr('y', chartHeight + margin.bottom - 5)
-    .attr('text-anchor', 'middle')
-    .attr('fill', accentColor)
-    .text('Week');
+  const yAxis = g.append("g").call(
+    d3
+      .axisLeft(y)
+      .ticks(5)
+      .tickFormat((d) => {
+        return Math.abs(d) >= 1000 ? Math.round(d / 1000) + "k" : d;
+      }),
+  );
+  g.append("text")
+    .attr("x", chartWidth / 2)
+    .attr("y", chartHeight + margin.bottom - 5)
+    .attr("text-anchor", "middle")
+    .attr("fill", accentColor)
+    .text("Week");
 
-  const zoom = d3.zoom()
+  const zoom = d3
+    .zoom()
     .scaleExtent([1, 10])
-    .translateExtent([[0, 0], [chartWidth, chartHeight]])
-    .extent([[0, 0], [chartWidth, chartHeight]])
-    .on('zoom', event => {
+    .translateExtent([
+      [0, 0],
+      [chartWidth, chartHeight],
+    ])
+    .extent([
+      [0, 0],
+      [chartWidth, chartHeight],
+    ])
+    .on("zoom", (event) => {
       const newX = event.transform.rescaleX(x);
       xAxis.call(d3.axisBottom(newX).ticks(10));
       const [xStart, xEnd] = newX.domain();
@@ -343,14 +396,22 @@ function drawChart(history) {
       }
       if (visible.length > 0) {
         y.domain(d3.extent(visible)).nice();
-        yAxis.call(d3.axisLeft(y).ticks(5).tickFormat(d => {
-          return Math.abs(d) >= 1000 ? Math.round(d / 1000) + 'k' : d;
-        }));
+        yAxis.call(
+          d3
+            .axisLeft(y)
+            .ticks(5)
+            .tickFormat((d) => {
+              return Math.abs(d) >= 1000 ? Math.round(d / 1000) + "k" : d;
+            }),
+        );
       }
-      pricePath.attr('d', d3.line()
-        .x((d, i) => newX(weeks[i]))
-        .y(d => y(d))
-        .curve(d3.curveMonotoneX)
+      pricePath.attr(
+        "d",
+        d3
+          .line()
+          .x((d, i) => newX(weeks[i]))
+          .y((d) => y(d))
+          .curve(d3.curveMonotoneX),
       );
     });
 
@@ -358,60 +419,67 @@ function drawChart(history) {
 }
 
 function updateAnalysisPanel() {
-  const tradeSel = document.getElementById('tradeSymbol');
-  const optSel = document.getElementById('optSymbol');
-  const sym = tradeSel ? tradeSel.value : (optSel ? optSel.value : null);
+  const tradeSel = document.getElementById("tradeSymbol");
+  const optSel = document.getElementById("optSymbol");
+  const sym = tradeSel ? tradeSel.value : optSel ? optSel.value : null;
   if (!sym) return;
-  const panel = document.getElementById('analysisPanel');
-  if (panel) panel.classList.remove('hidden');
+  const panel = document.getElementById("analysisPanel");
+  if (panel) panel.classList.remove("hidden");
   const historyWeeks = gameState.prices[sym] || [];
-  const closes = historyWeeks.map(w => w[w.length - 1]);
+  const closes = historyWeeks.map((w) => w[w.length - 1]);
   drawChart(closes);
   if (closes.length > 0) {
-    document.getElementById('price').textContent = closes[closes.length - 1].toFixed(2);
-    document.getElementById('average').textContent = computeAverage(closes).toFixed(2);
-    document.getElementById('high').textContent = Math.max(...closes).toFixed(2);
-    document.getElementById('low').textContent = Math.min(...closes).toFixed(2);
+    document.getElementById("price").textContent =
+      closes[closes.length - 1].toFixed(2);
+    document.getElementById("average").textContent =
+      computeAverage(closes).toFixed(2);
+    document.getElementById("high").textContent = Math.max(...closes).toFixed(
+      2,
+    );
+    document.getElementById("low").textContent = Math.min(...closes).toFixed(2);
   } else {
-    document.getElementById('average').textContent = '0';
-    document.getElementById('high').textContent = '0';
-    document.getElementById('low').textContent = '0';
+    document.getElementById("average").textContent = "0";
+    document.getElementById("high").textContent = "0";
+    document.getElementById("low").textContent = "0";
   }
   const vol = computeVolatility(closes);
-  document.getElementById('volatility').textContent = vol.toFixed(4);
+  document.getElementById("volatility").textContent = vol.toFixed(4);
 }
 
 function updateRank() {
   const prev = gameState.rank;
   const worth = gameState.netWorth;
-  const ranks = ['Novice', 'Apprentice', 'Trader', 'Tycoon'];
+  const ranks = ["Novice", "Apprentice", "Trader", "Tycoon"];
   const prevIndex = ranks.indexOf(prev);
-  const newIndex = worth > 1000000 ? 3
-                   : worth > 250000 ? 2
-                   : worth > 50000 ? 1
-                   : 0;
+  const newIndex =
+    worth > 1000000 ? 3 : worth > 250000 ? 2 : worth > 50000 ? 1 : 0;
   if (newIndex > prevIndex) {
     gameState.rank = ranks[newIndex];
   }
-  if (gameState.rank === 'Apprentice' && prev !== 'Apprentice' &&
-      typeof hasSeenApprentice === 'function' &&
-      typeof setApprenticeSeen === 'function' &&
-      !hasSeenApprentice()) {
-    if (typeof showMessage === 'function') {
-      showMessage("Well look at that, you're an Apprentice. Options unlocked. Try not to blow up.");
+  if (
+    gameState.rank === "Apprentice" &&
+    prev !== "Apprentice" &&
+    typeof hasSeenApprentice === "function" &&
+    typeof setApprenticeSeen === "function" &&
+    !hasSeenApprentice()
+  ) {
+    if (typeof showMessage === "function") {
+      showMessage(
+        "Well look at that, you're an Apprentice. Options unlocked. Try not to blow up.",
+      );
     }
     setApprenticeSeen();
   }
 }
 
 function doBuy() {
-  const sym = document.getElementById('tradeSymbol').value.trim().toUpperCase();
-  const qty = parseInt(document.getElementById('tradeQty').value, 10);
+  const sym = document.getElementById("tradeSymbol").value.trim().toUpperCase();
+  const qty = parseInt(document.getElementById("tradeQty").value, 10);
   if (!sym || !qty) return;
   const weeks = gameState.prices[sym];
   if (!weeks) {
-    if (typeof showMessage === 'function') {
-      showMessage('Unknown symbol');
+    if (typeof showMessage === "function") {
+      showMessage("Unknown symbol");
     }
     return;
   }
@@ -419,13 +487,22 @@ function doBuy() {
   const price = week[week.length - 1];
   const result = buyStock(gameState, sym, qty, price);
   if (!result.success) {
-    if (typeof showMessage === 'function') {
-      showMessage('Not enough cash');
+    if (typeof showMessage === "function") {
+      showMessage("Not enough cash");
     }
   } else {
     updateRank();
     if (!gameState.tradeHistory) gameState.tradeHistory = [];
-    const trade = { week: gameState.week, type: 'BUY', symbol: sym, qty, price, commission: result.commission, fees: result.fees, total: result.total };
+    const trade = {
+      week: gameState.week,
+      type: "BUY",
+      symbol: sym,
+      qty,
+      price,
+      commission: result.commission,
+      fees: result.fees,
+      total: result.total,
+    };
     gameState.tradeHistory.push(trade);
     saveState(gameState);
     showTradeDialog(trade);
@@ -437,13 +514,13 @@ function doBuy() {
 }
 
 function doSell() {
-  const sym = document.getElementById('tradeSymbol').value.trim().toUpperCase();
-  const qty = parseInt(document.getElementById('tradeQty').value, 10);
+  const sym = document.getElementById("tradeSymbol").value.trim().toUpperCase();
+  const qty = parseInt(document.getElementById("tradeQty").value, 10);
   if (!sym || !qty) return;
   const weeks = gameState.prices[sym];
   if (!weeks) {
-    if (typeof showMessage === 'function') {
-      showMessage('Unknown symbol');
+    if (typeof showMessage === "function") {
+      showMessage("Unknown symbol");
     }
     return;
   }
@@ -451,13 +528,22 @@ function doSell() {
   const price = week[week.length - 1];
   const result = sellStock(gameState, sym, qty, price);
   if (!result.success) {
-    if (typeof showMessage === 'function') {
-      showMessage('Not enough shares');
+    if (typeof showMessage === "function") {
+      showMessage("Not enough shares");
     }
   } else {
     updateRank();
     if (!gameState.tradeHistory) gameState.tradeHistory = [];
-    const trade = { week: gameState.week, type: 'SELL', symbol: sym, qty, price, commission: result.commission, fees: result.fees, total: result.total };
+    const trade = {
+      week: gameState.week,
+      type: "SELL",
+      symbol: sym,
+      qty,
+      price,
+      commission: result.commission,
+      fees: result.fees,
+      total: result.total,
+    };
     gameState.tradeHistory.push(trade);
     saveState(gameState);
     showTradeDialog(trade);
@@ -469,27 +555,60 @@ function doSell() {
 }
 
 function doBuyOption() {
-  const sym = document.getElementById('optSymbol').value.trim().toUpperCase();
-  const type = document.getElementById('optType').value;
-  const strike = parseFloat(document.getElementById('optStrike').value);
-  const qty = parseInt(document.getElementById('optQty').value, 10);
-  const w = parseInt(document.getElementById('optWeeks').value, 10);
+  const sym = document.getElementById("optSymbol").value.trim().toUpperCase();
+  const type = document.getElementById("optType").value;
+  const strike = parseFloat(document.getElementById("optStrike").value);
+  const qty = parseInt(document.getElementById("optQty").value, 10);
+  const w = parseInt(document.getElementById("optWeeks").value, 10);
   if (!sym || !qty || isNaN(strike) || isNaN(w)) return;
   const weeks = gameState.prices[sym];
-  if (!weeks || !bsPrice) { if (typeof showMessage==='function') showMessage('Unknown symbol'); return; }
-  const price = weeks[weeks.length-1][weeks[weeks.length-1].length-1];
-  const premium = bsPrice(price, strike, OPTION_RISK_FREE_RATE, OPTION_VOLATILITY, w/52, type);
+  if (!weeks || !bsPrice) {
+    if (typeof showMessage === "function") showMessage("Unknown symbol");
+    return;
+  }
+  const price = weeks[weeks.length - 1][weeks[weeks.length - 1].length - 1];
+  const premium = bsPrice(
+    price,
+    strike,
+    OPTION_RISK_FREE_RATE,
+    OPTION_VOLATILITY,
+    w / 52,
+    type,
+  );
   const tradeValue = premium * qty;
   const commission = TRADE_COMMISSION;
   const fees = +(tradeValue * TRADE_FEE_RATE).toFixed(2);
   const total = tradeValue + commission + fees;
-  if (gameState.cash < total) { if (typeof showMessage==='function') showMessage('Not enough cash'); return; }
+  if (gameState.cash < total) {
+    if (typeof showMessage === "function") showMessage("Not enough cash");
+    return;
+  }
   gameState.cash -= total;
   if (!gameState.options) gameState.options = [];
-  gameState.options.push({ symbol: sym, type, strike, premium, qty, weeksToExpiry: w, purchaseWeek: gameState.week });
+  gameState.options.push({
+    symbol: sym,
+    type,
+    strike,
+    premium,
+    qty,
+    weeksToExpiry: w,
+    purchaseWeek: gameState.week,
+  });
   updateRank();
   if (!gameState.tradeHistory) gameState.tradeHistory = [];
-  const trade = { week: gameState.week, type: `BUY ${type.toUpperCase()}`, symbol: sym, strike, optionType: type, weeks: w, qty, price: premium, commission, fees, total };
+  const trade = {
+    week: gameState.week,
+    type: `BUY ${type.toUpperCase()}`,
+    symbol: sym,
+    strike,
+    optionType: type,
+    weeks: w,
+    qty,
+    price: premium,
+    commission,
+    fees,
+    total,
+  };
   gameState.tradeHistory.push(trade);
   saveState(gameState);
   showTradeDialog(trade);
@@ -498,69 +617,46 @@ function doBuyOption() {
   renderSellOptions();
 }
 
-function populateSellOptionSelect() {
-  const select = document.getElementById('sellOptionSelect');
-  if (!select) return;
-  select.innerHTML = '';
-  (gameState.options || []).forEach((opt, idx) => {
-    const remaining = opt.weeksToExpiry - (gameState.week - opt.purchaseWeek);
-    if (remaining <= 0) return;
-    const o = document.createElement('option');
-    o.value = idx;
-    o.textContent = `${opt.symbol} ${opt.type} ${opt.strike} (qty ${opt.qty})`;
-    select.appendChild(o);
-  });
-  updateSellOptionSelection();
-}
-
-function updateSellOptionSelection() {
-  const select = document.getElementById('sellOptionSelect');
-  const idx = parseInt(select.value, 10) || 0;
+function closeOptionPosition(idx) {
   const opt = (gameState.options || [])[idx];
   if (!opt) return;
-  document.getElementById('optSymbol').value = opt.symbol;
-  document.getElementById('optType').value = opt.type;
-  document.getElementById('optStrike').value = opt.strike;
-  const qtyInput = document.getElementById('optQty');
-  if (qtyInput) {
-    qtyInput.max = opt.qty;
-    if (+qtyInput.value > opt.qty) qtyInput.value = opt.qty;
+  const remaining = opt.weeksToExpiry - (gameState.week - opt.purchaseWeek);
+  if (remaining <= 0) return;
+  const weeks = gameState.prices[opt.symbol];
+  if (!weeks || !bsPrice) {
+    if (typeof showMessage === "function") showMessage("Unknown symbol");
+    return;
   }
-}
-
-function selectOptionForSell(idx) {
-  const select = document.getElementById('sellOptionSelect');
-  if (!select) return;
-  select.value = idx;
-  updateSellOptionSelection();
-  const qtyInput = document.getElementById('optQty');
-  if (qtyInput) qtyInput.focus();
-}
-
-function doSellOption() {
-  const sym = document.getElementById('optSymbol').value.trim().toUpperCase();
-  const type = document.getElementById('optType').value;
-  const strike = parseFloat(document.getElementById('optStrike').value);
-  const qty = parseInt(document.getElementById('optQty').value, 10);
-  if (!sym || !qty || isNaN(strike)) return;
-  const idx = (gameState.options || []).findIndex(o => o.symbol===sym && o.type===type && o.strike===strike && o.qty>=qty && (o.weeksToExpiry - (gameState.week - o.purchaseWeek) > 0));
-  if (idx === -1) { if (typeof showMessage==='function') showMessage('No matching option position'); return; }
-  const optPos = gameState.options[idx];
-  const remaining = optPos.weeksToExpiry - (gameState.week - optPos.purchaseWeek);
-  const weeks = gameState.prices[sym];
-  if (!weeks || !bsPrice) { if (typeof showMessage==='function') showMessage('Unknown symbol'); return; }
-  const price = weeks[weeks.length-1][weeks[weeks.length-1].length-1];
-  const premium = bsPrice(price, strike, OPTION_RISK_FREE_RATE, OPTION_VOLATILITY, remaining/52, type);
-  const tradeValue = premium * qty;
+  const price = weeks[weeks.length - 1][weeks[weeks.length - 1].length - 1];
+  const premium = bsPrice(
+    price,
+    opt.strike,
+    OPTION_RISK_FREE_RATE,
+    OPTION_VOLATILITY,
+    remaining / 52,
+    opt.type,
+  );
+  const tradeValue = premium * opt.qty;
   const commission = TRADE_COMMISSION;
   const fees = +(tradeValue * TRADE_FEE_RATE).toFixed(2);
   const proceeds = tradeValue - commission - fees;
   gameState.cash += proceeds;
-  optPos.qty -= qty;
-  if (optPos.qty <= 0) gameState.options.splice(idx,1);
+  gameState.options.splice(idx, 1);
   updateRank();
   if (!gameState.tradeHistory) gameState.tradeHistory = [];
-  const trade = { week: gameState.week, type: `SELL ${type.toUpperCase()}`, symbol: sym, strike, optionType: type, weeks: remaining, qty, price: premium, commission, fees, total: proceeds };
+  const trade = {
+    week: gameState.week,
+    type: `SELL ${opt.type.toUpperCase()}`,
+    symbol: opt.symbol,
+    strike: opt.strike,
+    optionType: opt.type,
+    weeks: remaining,
+    qty: opt.qty,
+    price: premium,
+    commission,
+    fees,
+    total: proceeds,
+  };
   gameState.tradeHistory.push(trade);
   saveState(gameState);
   showTradeDialog(trade);
@@ -569,81 +665,87 @@ function doSellOption() {
   renderSellOptions();
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   gameState = loadState();
-  if (gameState && (gameState.week >= gameState.maxWeeks || gameState.gameOver)) {
-    window.location.href = 'game-over.html';
+  if (
+    gameState &&
+    (gameState.week >= gameState.maxWeeks || gameState.gameOver)
+  ) {
+    window.location.href = "game-over.html";
     return;
   }
   renderMetrics();
   renderTradeHistory();
   renderSellOptions();
-  fetch('data/company_master_data.json')
-    .then(r => r.json())
-    .then(data => {
+  fetch("data/company_master_data.json")
+    .then((r) => r.json())
+    .then((data) => {
       companies = data.companies;
       renderMetrics();
       renderTradeHistory();
-      const optForm = document.getElementById('optionsForm');
-      const unlocked = gameState.rank !== 'Novice' ||
-                       (typeof hasSeenApprentice === 'function' && hasSeenApprentice());
+      const optForm = document.getElementById("optionsForm");
+      const unlocked =
+        gameState.rank !== "Novice" ||
+        (typeof hasSeenApprentice === "function" && hasSeenApprentice());
       if (unlocked && optForm) {
-        populateOptionSymbols(companies.filter(c => !c.isIndex));
+        populateOptionSymbols(companies.filter((c) => !c.isIndex));
         populateOptionDetails();
-        optForm.classList.remove('hidden');
+        optForm.classList.remove("hidden");
         updateOptionInfo();
         renderSellOptions();
       }
     });
 
-  const tradeSymbol = document.getElementById('tradeSymbol');
-  if (tradeSymbol) tradeSymbol.addEventListener('change', updateTradeInfo);
-  const tradeQtySlider = document.getElementById('tradeQtySlider');
-  const tradeQtyInput = document.getElementById('tradeQty');
-  if (tradeQtySlider) tradeQtySlider.addEventListener('input', e => {
-    if (tradeQtyInput) tradeQtyInput.value = e.target.value;
-    updateTradeTotal();
-  });
-  if (tradeQtyInput) tradeQtyInput.addEventListener('input', e => {
-    if (tradeQtySlider) tradeQtySlider.value = e.target.value;
-    updateTradeTotal();
-  });
-  const buyBtn = document.getElementById('buyBtn');
-  if (buyBtn) buyBtn.addEventListener('click', doBuy);
-  const sellBtn = document.getElementById('sellBtn');
-  if (sellBtn) sellBtn.addEventListener('click', doSell);
-  const startBuyBtn = document.getElementById('startBuyBtn');
-  if (startBuyBtn) startBuyBtn.addEventListener('click', () => showOrderForm('BUY'));
-  const startSellBtn = document.getElementById('startSellBtn');
-  if (startSellBtn) startSellBtn.addEventListener('click', () => showOrderForm('SELL'));
-  const cancelTradeBtn = document.getElementById('cancelTradeBtn');
-  if (cancelTradeBtn) cancelTradeBtn.addEventListener('click', hideOrderForm);
-
-  const unlocked = gameState.rank !== 'Novice' ||
-                   (typeof hasSeenApprentice === 'function' && hasSeenApprentice());
-  if (unlocked) {
-    const optSymbol = document.getElementById('optSymbol');
-    if (optSymbol) optSymbol.addEventListener('change', () => {
-      populateOptionDetails();
-      updateOptionInfo();
+  const tradeSymbol = document.getElementById("tradeSymbol");
+  if (tradeSymbol) tradeSymbol.addEventListener("change", updateTradeInfo);
+  const tradeQtySlider = document.getElementById("tradeQtySlider");
+  const tradeQtyInput = document.getElementById("tradeQty");
+  if (tradeQtySlider)
+    tradeQtySlider.addEventListener("input", (e) => {
+      if (tradeQtyInput) tradeQtyInput.value = e.target.value;
+      updateTradeTotal();
     });
-    const optType = document.getElementById('optType');
-    if (optType) optType.addEventListener('change', updateOptionInfo);
-    const optStrike = document.getElementById('optStrike');
-    if (optStrike) optStrike.addEventListener('change', updateOptionInfo);
-    const optWeeks = document.getElementById('optWeeks');
-    if (optWeeks) optWeeks.addEventListener('change', updateOptionInfo);
-    const optQty = document.getElementById('optQty');
-    if (optQty) optQty.addEventListener('input', updateOptionInfo);
-    const optBuyBtn = document.getElementById('optBuyBtn');
-    if (optBuyBtn) optBuyBtn.addEventListener('click', doBuyOption);
-    const optSellBtn = document.getElementById('optSellBtn');
-    if (optSellBtn) optSellBtn.addEventListener('click', doSellOption);
-    const sellSelect = document.getElementById('sellOptionSelect');
-    if (sellSelect) sellSelect.addEventListener('change', updateSellOptionSelection);
+  if (tradeQtyInput)
+    tradeQtyInput.addEventListener("input", (e) => {
+      if (tradeQtySlider) tradeQtySlider.value = e.target.value;
+      updateTradeTotal();
+    });
+  const buyBtn = document.getElementById("buyBtn");
+  if (buyBtn) buyBtn.addEventListener("click", doBuy);
+  const sellBtn = document.getElementById("sellBtn");
+  if (sellBtn) sellBtn.addEventListener("click", doSell);
+  const startBuyBtn = document.getElementById("startBuyBtn");
+  if (startBuyBtn)
+    startBuyBtn.addEventListener("click", () => showOrderForm("BUY"));
+  const startSellBtn = document.getElementById("startSellBtn");
+  if (startSellBtn)
+    startSellBtn.addEventListener("click", () => showOrderForm("SELL"));
+  const cancelTradeBtn = document.getElementById("cancelTradeBtn");
+  if (cancelTradeBtn) cancelTradeBtn.addEventListener("click", hideOrderForm);
+
+  const unlocked =
+    gameState.rank !== "Novice" ||
+    (typeof hasSeenApprentice === "function" && hasSeenApprentice());
+  if (unlocked) {
+    const optSymbol = document.getElementById("optSymbol");
+    if (optSymbol)
+      optSymbol.addEventListener("change", () => {
+        populateOptionDetails();
+        updateOptionInfo();
+      });
+    const optType = document.getElementById("optType");
+    if (optType) optType.addEventListener("change", updateOptionInfo);
+    const optStrike = document.getElementById("optStrike");
+    if (optStrike) optStrike.addEventListener("change", updateOptionInfo);
+    const optWeeks = document.getElementById("optWeeks");
+    if (optWeeks) optWeeks.addEventListener("change", updateOptionInfo);
+    const optQty = document.getElementById("optQty");
+    if (optQty) optQty.addEventListener("input", updateOptionInfo);
+    const optBuyBtn = document.getElementById("optBuyBtn");
+    if (optBuyBtn) optBuyBtn.addEventListener("click", doBuyOption);
   }
 });
 
-window.addEventListener('resize', () => {
+window.addEventListener("resize", () => {
   if (currentHistory.length > 0) drawChart(currentHistory);
 });

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -1,23 +1,30 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Drawdown - Trade Options</title>
-  <link rel="stylesheet" href="css/style.css" />
-  <script src="https://d3js.org/d3.v7.min.js"></script>
-</head>
-<body class="amber">
-  <div class="trade-container">
-    <h1>Trade Stock Options</h1>
-    <table class="metrics-table">
-      <tr><th>Worth</th><td>$<span id="tNetWorth">0</span></td></tr>
-      <tr><th>Cash</th><td>$<span id="tCash">0</span></td></tr>
-    </table>
-    <div id="optionsForm">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Drawdown - Trade Options</title>
+    <link rel="stylesheet" href="css/style.css" />
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+  </head>
+  <body class="amber">
+    <div class="trade-container">
+      <h1>Trade Stock Options</h1>
+      <table class="metrics-table">
+        <tr>
+          <th>Worth</th>
+          <td>$<span id="tNetWorth">0</span></td>
+        </tr>
+        <tr>
+          <th>Cash</th>
+          <td>$<span id="tCash">0</span></td>
+        </tr>
+      </table>
+      <div id="optionsForm">
         <h3>Options</h3>
-        <label for="optSymbol">Symbol</label><br/>
-        <select id="optSymbol"></select><br/>
+        <label for="optSymbol">Symbol</label><br />
+        <select id="optSymbol"></select
+        ><br />
         <div id="analysisPanel" class="hidden">
           <div id="metrics">
             <div>Price: $<span id="price">0</span></div>
@@ -29,50 +36,54 @@
           <div class="chart-wrapper">
             <div id="companyChart"></div>
           </div>
-          <p class="analysis-note">Options prices are calculated using the Black-Scholes model.</p>
+          <p class="analysis-note">
+            Options prices are calculated using the Black-Scholes model.
+          </p>
         </div>
-        <label for="optType">Type</label><br/>
+        <label for="optType">Type</label><br />
         <select id="optType">
           <option value="call">Call</option>
-          <option value="put">Put</option>
-        </select><br/>
-        <label for="optStockPrice">Current Price</label><br/>
-        $<span id="optStockPrice">0.00</span><br/>
-        <label for="optStrike">Strike</label><br/>
-        <select id="optStrike"></select><br/>
-        <label for="optWeeks">Weeks to Expiry</label><br/>
-        <select id="optWeeks"></select><br/>
-        <label for="sellOptionSelect">Owned Option</label><br/>
-        <select id="sellOptionSelect"></select><br/>
-        <label for="optQty">Contracts</label><br/>
-        <input id="optQty" type="number" min="1" value="1" /><br/>
+          <option value="put">Put</option></select
+        ><br />
+        <label for="optStockPrice">Current Price</label><br />
+        $<span id="optStockPrice">0.00</span><br />
+        <label for="optStrike">Strike</label><br />
+        <select id="optStrike"></select
+        ><br />
+        <label for="optWeeks">Weeks to Expiry</label><br />
+        <select id="optWeeks"></select
+        ><br />
+        <label for="optQty">Contracts</label><br />
+        <input id="optQty" type="number" min="1" value="1" /><br />
         <div>Premium: $<span id="optPremium">0.00</span></div>
         <div>Total Cost: $<span id="optTotal">0.00</span></div>
         <button type="button" id="optBuyBtn">Buy Option</button>
-        <button type="button" id="optSellBtn">Sell Option</button>
       </div>
       <div id="optionsHoldings" class="hidden">
         <h3>Your Options</h3>
         <table id="sellOptionsTable"></table>
       </div>
-    <div id="tradeConfirm" class="confirm-message"></div>
-    <table id="tradeHistoryTable"></table>
-    <div class="analysis-nav">
-      <button type="button" onclick="location.href='play.html'">Back</button>
+      <div id="tradeConfirm" class="confirm-message"></div>
+      <table id="tradeHistoryTable"></table>
+      <div class="analysis-nav">
+        <button type="button" onclick="location.href='play.html'">Back</button>
+      </div>
     </div>
-  </div>
-  <script src="js/storage.js"></script>
-  <script>
-    const state = loadState();
-    const apprentice = typeof hasSeenApprentice === 'function' && hasSeenApprentice();
-    if (!state || (state.rank === 'Novice' && !apprentice)) {
-      window.location.href = 'play.html';
-    }
-  </script>
-  <script src="js/options.js"></script>
-  <script src="js/player.js"></script>
-  <script src="js/dialog.js"></script>
-  <script>window.optionsTradeHistoryOnly = true;</script>
-  <script src="js/trade.js"></script>
-</body>
+    <script src="js/storage.js"></script>
+    <script>
+      const state = loadState();
+      const apprentice =
+        typeof hasSeenApprentice === "function" && hasSeenApprentice();
+      if (!state || (state.rank === "Novice" && !apprentice)) {
+        window.location.href = "play.html";
+      }
+    </script>
+    <script src="js/options.js"></script>
+    <script src="js/player.js"></script>
+    <script src="js/dialog.js"></script>
+    <script>
+      window.optionsTradeHistoryOnly = true;
+    </script>
+    <script src="js/trade.js"></script>
+  </body>
 </html>

--- a/docs/trade.html
+++ b/docs/trade.html
@@ -1,20 +1,26 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Drawdown - Trade</title>
-  <link rel="stylesheet" href="css/style.css" />
-  <script src="https://d3js.org/d3.v7.min.js"></script>
-</head>
-<body>
-  <div class="trade-container">
-    <h1>Trade</h1>
-    <table class="metrics-table">
-      <tr><th>Worth</th><td>$<span id="tNetWorth">0</span></td></tr>
-      <tr><th>Cash</th><td>$<span id="tCash">0</span></td></tr>
-    </table>
-    <div id="tradeModeSelect">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Drawdown - Trade</title>
+    <link rel="stylesheet" href="css/style.css" />
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+  </head>
+  <body>
+    <div class="trade-container">
+      <h1>Trade</h1>
+      <table class="metrics-table">
+        <tr>
+          <th>Worth</th>
+          <td>$<span id="tNetWorth">0</span></td>
+        </tr>
+        <tr>
+          <th>Cash</th>
+          <td>$<span id="tCash">0</span></td>
+        </tr>
+      </table>
+      <div id="tradeModeSelect">
         <button type="button" id="startBuyBtn">Buy Order</button>
         <button type="button" id="startSellBtn">Sell Order</button>
       </div>
@@ -25,8 +31,9 @@
       </div>
 
       <div id="tradeForm" class="hidden">
-        <label for="tradeSymbol">Symbol</label><br/>
-        <select id="tradeSymbol"></select><br/>
+        <label for="tradeSymbol">Symbol</label><br />
+        <select id="tradeSymbol"></select
+        ><br />
         <div id="analysisPanel" class="hidden">
           <div id="metrics">
             <div>Price: $<span id="price">0</span></div>
@@ -38,13 +45,19 @@
           <div class="chart-wrapper">
             <div id="companyChart"></div>
           </div>
-          <p class="analysis-note">Options prices are calculated using the Black-Scholes model.</p>
+          <p class="analysis-note">
+            Options prices are calculated using the Black-Scholes model.
+          </p>
         </div>
         <div>Price: $<span id="tradePrice">0.00</span></div>
-        <label for="tradeQty">Quantity</label><br/>
-        <input id="tradeQty" type="number" min="1" value="1" /><br/>
-        <input id="tradeQtySlider" type="range" min="1" value="1" /><br/>
-        <div><span id="tradeTotalLabel">Total Cost:</span> $<span id="tradeTotal">0.00</span></div>
+        <label for="tradeQty">Quantity</label><br />
+        <input id="tradeQty" type="number" min="1" value="1" /><br />
+        <input id="tradeQtySlider" type="range" min="1" value="1" /><br />
+        <div>
+          <span id="tradeTotalLabel">Total Cost:</span> $<span id="tradeTotal"
+            >0.00</span
+          >
+        </div>
         <button type="button" id="buyBtn">Execute Order</button>
         <button type="button" id="sellBtn">Execute Order</button>
         <button type="button" id="cancelTradeBtn">Cancel</button>
@@ -52,40 +65,42 @@
 
       <div id="optionsForm" class="hidden">
         <h3>Options</h3>
-        <label for="optSymbol">Symbol</label><br/>
-        <select id="optSymbol"></select><br/>
-        <label for="optType">Type</label><br/>
+        <label for="optSymbol">Symbol</label><br />
+        <select id="optSymbol"></select
+        ><br />
+        <label for="optType">Type</label><br />
         <select id="optType">
           <option value="call">Call</option>
-          <option value="put">Put</option>
-        </select><br/>
-        <label for="optStockPrice">Current Price</label><br/>
-        $<span id="optStockPrice">0.00</span><br/>
-        <label for="optStrike">Strike</label><br/>
-        <select id="optStrike"></select><br/>
-        <label for="optWeeks">Weeks to Expiry</label><br/>
-        <select id="optWeeks"></select><br/>
-        <label for="optQty">Contracts</label><br/>
-        <input id="optQty" type="number" min="1" value="1" /><br/>
+          <option value="put">Put</option></select
+        ><br />
+        <label for="optStockPrice">Current Price</label><br />
+        $<span id="optStockPrice">0.00</span><br />
+        <label for="optStrike">Strike</label><br />
+        <select id="optStrike"></select
+        ><br />
+        <label for="optWeeks">Weeks to Expiry</label><br />
+        <select id="optWeeks"></select
+        ><br />
+        <label for="optQty">Contracts</label><br />
+        <input id="optQty" type="number" min="1" value="1" /><br />
         <div>Premium: $<span id="optPremium">0.00</span></div>
         <div>Total Cost: $<span id="optTotal">0.00</span></div>
         <button type="button" id="optBuyBtn">Buy Option</button>
-        <button type="button" id="optSellBtn">Sell Option</button>
       </div>
       <div id="optionsHoldings" class="hidden">
         <h3>Your Options</h3>
         <table id="sellOptionsTable"></table>
       </div>
-    <div id="tradeConfirm" class="confirm-message"></div>
-    <table id="tradeHistoryTable"></table>
-    <div class="analysis-nav">
-      <button type="button" onclick="location.href='play.html'">Back</button>
+      <div id="tradeConfirm" class="confirm-message"></div>
+      <table id="tradeHistoryTable"></table>
+      <div class="analysis-nav">
+        <button type="button" onclick="location.href='play.html'">Back</button>
+      </div>
     </div>
-  </div>
-  <script src="js/storage.js"></script>
-  <script src="js/options.js"></script>
-  <script src="js/player.js"></script>
-  <script src="js/dialog.js"></script>
-  <script src="js/trade.js"></script>
-</body>
+    <script src="js/storage.js"></script>
+    <script src="js/options.js"></script>
+    <script src="js/player.js"></script>
+    <script src="js/dialog.js"></script>
+    <script src="js/trade.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- center trade history table
- remove drop-down sell flow
- add `close position` button for options

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_687415aa8f148325847f132305f749b4