### PR TITLE
Remove extraneous Black-Scholes note from stock trading page

### DIFF
--- a/docs/trade-stocks.html
+++ b/docs/trade-stocks.html
@@ -38,7 +38,6 @@
           <div class="chart-wrapper">
             <div id="companyChart"></div>
           </div>
-          <p class="analysis-note">Options prices are calculated using the Black-Scholes model.</p>
         </div>
         <div>Price: $<span id="tradePrice">0.00</span></div>
         <label for="tradeQty">Quantity</label><br/>


### PR DESCRIPTION
## Summary
- remove reference to Black-Scholes option pricing from `trade-stocks.html`

## Testing
- `node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_6874ca1be47c8325bbd9cdcb215cd61c