### PR TITLE
Add applyNewsEffects test

### DIFF
--- a/tests/test_news_engine.js
+++ b/tests/test_news_engine.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { maybeGenerateIndustryNews, TUNABLES, INDUSTRIES } = require('../docs/js/news_engine.js');
+const { maybeGenerateIndustryNews, applyNewsEffects, INDUSTRIES } = require('../docs/js/news_engine.js');
 
 function testMaybeGenerateIndustryNews() {
   // Stub Math.random to deterministic value so at least one event triggers
@@ -25,11 +25,50 @@ function testMaybeGenerateIndustryNews() {
   assert.ok(INDUSTRIES.includes(event.industry));
 }
 
+function testApplyNewsEffects() {
+  const stocks = [
+    { industry: 'Software', jump: 0, driftBump: [] },
+    { industry: 'Energy', jump: 0, driftBump: [] },
+    { industry: 'Banking', jump: 0, driftBump: [] }
+  ];
+  const events = [
+    { industry: 'Software', sentiment: 1 },
+    { industry: 'Energy', sentiment: -1 }
+  ];
+  const baseJump = 0.02;
+  const baseDelta = 0.01;
+  const days = 5;
+
+  const originalRandom = Math.random;
+  Math.random = () => 0.5; // Deterministic eps
+
+  applyNewsEffects(stocks, events, baseJump, baseDelta, days);
+
+  Math.random = originalRandom;
+
+  // Software event positive
+  assert.strictEqual(stocks[0].jump, baseJump);
+  assert.strictEqual(stocks[0].driftBump.length, 1);
+  assert.strictEqual(stocks[0].driftBump[0].delta, baseDelta);
+  assert.strictEqual(stocks[0].driftBump[0].daysLeft, days);
+
+  // Energy event negative
+  assert.strictEqual(stocks[1].jump, -baseJump);
+  assert.strictEqual(stocks[1].driftBump.length, 1);
+  assert.strictEqual(stocks[1].driftBump[0].delta, -baseDelta);
+  assert.strictEqual(stocks[1].driftBump[0].daysLeft, days);
+
+  // Banking unaffected
+  assert.strictEqual(stocks[2].jump, 0);
+  assert.strictEqual(stocks[2].driftBump.length, 0);
+}
+
 try {
   testMaybeGenerateIndustryNews();
-  console.log('News engine test passed');
+  testApplyNewsEffects();
+  console.log('News engine tests passed');
 } catch (err) {
-  console.error('News engine test failed');
+  console.error('News engine tests failed');
   console.error(err);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- extend news engine test suite with deterministic applyNewsEffects checks

## Testing
- `node tests/test_news_engine.js`
- `node tests/test_networth_options.js`
- `node tests/test_player.js`


------
https://chatgpt.com/codex/tasks/task_e_6874cece9dc48325a9aff727ca15ba09