### PR TITLE
Add tests for options math

### DIFF
--- a/tests/test_options_math.js
+++ b/tests/test_options_math.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const { normCdf, erf } = require('../docs/js/options.js');
+
+function testNormCdfZero() {
+  assert.strictEqual(normCdf(0), 0.5);
+}
+
+function testNormCdfSymmetry() {
+  const samples = [-3, -1, -0.5, 0.5, 1, 3];
+  for (const x of samples) {
+    const expected = 1 - normCdf(-x);
+    assert.ok(Math.abs(normCdf(x) - expected) < 1e-12);
+  }
+}
+
+function testErfOne() {
+  const approx = 0.8427;
+  assert.ok(Math.abs(erf(1) - approx) < 1e-4);
+}
+
+try {
+  testNormCdfZero();
+  testNormCdfSymmetry();
+  testErfOne();
+  console.log('Options math tests passed');
+} catch (err) {
+  console.error('Options math tests failed');
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add unit tests for normCdf and erf

## Testing
- `for f in tests/test_*.js; do node $f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_6874d03d2a1c8325ab3e036dadf49d3c