### PR TITLE
Reduce chart display width

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -143,7 +143,8 @@ button:hover {
 
 .chart-wrapper {
   margin: 1rem auto;
-  max-width: 600px;
+  width: 90%;
+  max-width: 540px;
 }
 
 #marketChart,


### PR DESCRIPTION
## Summary
- shrink charts by ~10% to keep them smaller on all screens

## Testing
- `node tests/test_options_math.js && node tests/test_news_engine.js && node tests/test_player.js && node tests/test_networth_options.js`

------
https://chatgpt.com/codex/tasks/task_e_6874d136647c832582db5aa7eb62cf2a