### PR TITLE
Simplify trade‑stocks info

### DIFF
--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -7,12 +7,12 @@ let currentHistory = [];
 function renderMetrics() {
   if (!gameState) return;
   computeNetWorth(gameState);
-  document.getElementById("tNetWorth").textContent = Math.round(
-    gameState.netWorth,
-  ).toLocaleString();
-  document.getElementById("tCash").textContent = Math.round(
-    gameState.cash,
-  ).toLocaleString();
+  const worthEl = document.getElementById("tNetWorth");
+  if (worthEl)
+    worthEl.textContent = Math.round(gameState.netWorth).toLocaleString();
+  const cashEl = document.getElementById("tCash");
+  if (cashEl)
+    cashEl.textContent = Math.round(gameState.cash).toLocaleString();
 }
 
 function renderTradeHistory() {
@@ -429,21 +429,25 @@ function updateAnalysisPanel() {
   const closes = historyWeeks.map((w) => w[w.length - 1]);
   drawChart(closes);
   if (closes.length > 0) {
-    document.getElementById("price").textContent =
-      closes[closes.length - 1].toFixed(2);
-    document.getElementById("average").textContent =
-      computeAverage(closes).toFixed(2);
-    document.getElementById("high").textContent = Math.max(...closes).toFixed(
-      2,
-    );
-    document.getElementById("low").textContent = Math.min(...closes).toFixed(2);
+    const priceEl = document.getElementById("price");
+    if (priceEl) priceEl.textContent = closes[closes.length - 1].toFixed(2);
+    const avgEl = document.getElementById("average");
+    if (avgEl) avgEl.textContent = computeAverage(closes).toFixed(2);
+    const highEl = document.getElementById("high");
+    if (highEl) highEl.textContent = Math.max(...closes).toFixed(2);
+    const lowEl = document.getElementById("low");
+    if (lowEl) lowEl.textContent = Math.min(...closes).toFixed(2);
   } else {
-    document.getElementById("average").textContent = "0";
-    document.getElementById("high").textContent = "0";
-    document.getElementById("low").textContent = "0";
+    const avgEl = document.getElementById("average");
+    if (avgEl) avgEl.textContent = "0";
+    const highEl = document.getElementById("high");
+    if (highEl) highEl.textContent = "0";
+    const lowEl = document.getElementById("low");
+    if (lowEl) lowEl.textContent = "0";
   }
   const vol = computeVolatility(closes);
-  document.getElementById("volatility").textContent = vol.toFixed(4);
+  const volEl = document.getElementById("volatility");
+  if (volEl) volEl.textContent = vol.toFixed(4);
 }
 
 function updateRank() {

--- a/docs/trade-stocks.html
+++ b/docs/trade-stocks.html
@@ -9,11 +9,7 @@
 </head>
 <body>
   <div class="trade-container">
-    <h1>Trade Stocks</h1>
-    <table class="metrics-table">
-      <tr><th>Worth</th><td>$<span id="tNetWorth">0</span></td></tr>
-      <tr><th>Cash</th><td>$<span id="tCash">0</span></td></tr>
-    </table>
+    <h1>Trade Stocks (Cash: $<span id="tCash">0</span>)</h1>
     <div id="tradeModeSelect">
         <button type="button" id="startBuyBtn">Buy Order</button>
         <button type="button" id="startSellBtn">Sell Order</button>
@@ -28,13 +24,6 @@
         <label for="tradeSymbol">Symbol</label><br/>
         <select id="tradeSymbol"></select><br/>
         <div id="analysisPanel" class="hidden">
-          <div id="metrics">
-            <div>Price: $<span id="price">0</span></div>
-            <div>Volatility: <span id="volatility">0</span></div>
-            <div>Average: $<span id="average">0</span></div>
-            <div>High: $<span id="high">0</span></div>
-            <div>Low: $<span id="low">0</span></div>
-          </div>
           <div class="chart-wrapper">
             <div id="companyChart"></div>
           </div>


### PR DESCRIPTION
## Summary
- show player's available cash directly in the **Trade Stocks** heading
- drop net worth table and stock metrics from trade-stocks page
- guard metric rendering in trade.js so pages can omit these elements

## Testing
- `node tests/test_player.js && node tests/test_networth_options.js && node tests/test_options_math.js && node tests/test_news_engine.js`

------
https://chatgpt.com/codex/tasks/task_e_6874db731bf48325ab67cd9e72565cc3