### PR TITLE
Update trade-stocks back button placement

### DIFF
--- a/docs/trade-stocks.html
+++ b/docs/trade-stocks.html
@@ -13,6 +13,7 @@
     <div id="tradeModeSelect">
         <button type="button" id="startBuyBtn">Buy Order</button>
         <button type="button" id="startSellBtn">Sell Order</button>
+        <button type="button" onclick="location.href='play.html'">Back to weekly summary</button>
       </div>
 
       <div id="sellHoldings" class="hidden">
@@ -41,9 +42,6 @@
       
     <div id="tradeConfirm" class="confirm-message"></div>
     <table id="tradeHistoryTable"></table>
-    <div class="analysis-nav">
-      <button type="button" onclick="location.href='play.html'">Back</button>
-    </div>
   </div>
   <script src="js/storage.js"></script>
   <script src="js/player.js"></script>


### PR DESCRIPTION
## Summary
- move the Back button in `trade-stocks.html` next to the Buy/Sell buttons
- change text to *Back to weekly summary*

## Testing
- `node tests/test_networth_options.js && node tests/test_options_math.js && node tests/test_news_engine.js && node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_6874efaec00c8325a6edc8670470626e