### PR TITLE
Fix sell menu refresh

### DIFF
--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -552,8 +552,9 @@ function doSell() {
     saveState(gameState);
     showTradeDialog(trade);
     renderMetrics();
-    updateTradeInfo();
     renderSellHoldings();
+    populateTradeSymbols(getHoldingsList());
+    updateTradeInfo();
     renderTradeHistory();
   }
 }


### PR DESCRIPTION
## Summary
- refresh sell dropdown after selling shares

## Testing
- `node tests/test_player.js && node tests/test_networth_options.js && node tests/test_options_math.js && node tests/test_news_engine.js`

------
https://chatgpt.com/codex/tasks/task_e_6874fd5854248325aff4f0cbe7911407