### PR TITLE
Add debugging launcher

### DIFF
--- a/docs/debugging.html
+++ b/docs/debugging.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Drawdown - Debugging</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <p><a href="play.html?debug=apprentice" class="link-wrapper">Start at Apprentice Level</a></p>
+</body>
+</html>

--- a/docs/js/game.js
+++ b/docs/js/game.js
@@ -119,6 +119,11 @@ function newsImpactsForWeek(week) {
 
 }
 function startGame() {
+  const params = new URLSearchParams(window.location.search);
+  const debugApprentice = params.get('debug') === 'apprentice';
+  if (debugApprentice) {
+    localStorage.removeItem(getStorageKey());
+  }
   gameState = loadState();
   if (gameState && !gameState.positions) {
     gameState.positions = {};
@@ -166,6 +171,16 @@ function startGame() {
       gameState.prices[INDEX_SYMBOL].push(computeIndexWeekPrices(i));
     }
 
+    saveState(gameState);
+  }
+
+  if (debugApprentice) {
+    gameState.cash = 60000;
+    gameState.netWorth = 60000;
+    gameState.rank = 'Apprentice';
+    if (typeof setApprenticeSeen === 'function') {
+      setApprenticeSeen();
+    }
     saveState(gameState);
   }
   computeNetWorth(gameState);


### PR DESCRIPTION
## Summary
- create new `debugging.html` with link to start at Apprentice level
- allow `play.html` to accept `?debug=apprentice` which sets starting cash and rank

## Testing
- `node tests/test_player.js`
- `node tests/test_networth_options.js`
- `node tests/test_options_math.js`
- `node tests/test_news_engine.js`


------
https://chatgpt.com/codex/tasks/task_e_6875647a11b88325bb9edaea7519563a