### PR TITLE
Update trade options layout

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -290,6 +290,8 @@ select {
   width: auto;
   max-width: 400px;
   text-align: center;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 #tradeHistoryTable th,

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -13,6 +13,9 @@ function renderMetrics() {
   const cashEl = document.getElementById("tCash");
   if (cashEl)
     cashEl.textContent = Math.round(gameState.cash).toLocaleString();
+  const headerCash = document.getElementById("headerCash");
+  if (headerCash)
+    headerCash.textContent = Math.round(gameState.cash).toLocaleString();
 }
 
 function renderTradeHistory() {

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -9,7 +9,7 @@
   </head>
   <body class="amber">
     <div class="trade-container">
-      <h1>Trade Stock Options</h1>
+      <h1>Trade Stock Options (Cash: $<span id="headerCash">0</span>)</h1>
       <table class="metrics-table">
         <tr>
           <th>Worth</th>
@@ -26,19 +26,9 @@
         <select id="optSymbol"></select
         ><br />
         <div id="analysisPanel" class="hidden">
-          <div id="metrics">
-            <div>Price: $<span id="price">0</span></div>
-            <div>Volatility: <span id="volatility">0</span></div>
-            <div>Average: $<span id="average">0</span></div>
-            <div>High: $<span id="high">0</span></div>
-            <div>Low: $<span id="low">0</span></div>
-          </div>
           <div class="chart-wrapper">
             <div id="companyChart"></div>
           </div>
-          <p class="analysis-note">
-            Options prices are calculated using the Black-Scholes model.
-          </p>
         </div>
         <label for="optType">Type</label><br />
         <select id="optType">
@@ -58,6 +48,7 @@
         <div>Premium: $<span id="optPremium">0.00</span></div>
         <div>Total Cost: $<span id="optTotal">0.00</span></div>
         <button type="button" id="optBuyBtn">Buy Option</button>
+        <button type="button" onclick="location.href='play.html'">Back to Weekly Summary</button>
       </div>
       <div id="optionsHoldings" class="hidden">
         <h3>Your Options</h3>
@@ -65,9 +56,6 @@
       </div>
       <div id="tradeConfirm" class="confirm-message"></div>
       <table id="tradeHistoryTable"></table>
-      <div class="analysis-nav">
-        <button type="button" onclick="location.href='play.html'">Back</button>
-      </div>
     </div>
     <script src="js/storage.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- show cash balance in Trade Stock Options header and update dynamically
- remove metrics and Black-Scholes note from options analysis panel
- place the Back button next to Buy Option and rename it
- center the order history table

## Testing
- `node tests/test_options_math.js && node tests/test_player.js && node tests/test_networth_options.js`

------
https://chatgpt.com/codex/tasks/task_e_68761e49a538832580f8fa783c9806bc