### PR TITLE
Remove metrics table from options trading page

### DIFF
--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -10,16 +10,6 @@
   <body class="amber">
     <div class="trade-container">
       <h1>Trade Stock Options (Cash: $<span id="headerCash">0</span>)</h1>
-      <table class="metrics-table">
-        <tr>
-          <th>Worth</th>
-          <td>$<span id="tNetWorth">0</span></td>
-        </tr>
-        <tr>
-          <th>Cash</th>
-          <td>$<span id="tCash">0</span></td>
-        </tr>
-      </table>
       <div id="optionsForm">
         <h3>Options</h3>
         <label for="optSymbol">Symbol</label><br />


### PR DESCRIPTION
## Summary
- remove net worth/cash table on the trade options page

## Testing
- `node tests/test_networth_options.js && node tests/test_options_math.js && node tests/test_news_engine.js && node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_687620d3efec8325ab929dcc2cbde555