### PR TITLE
Implement option buy/sell flow

### DIFF
--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -240,6 +240,39 @@ function hideOrderForm() {
   document.getElementById("analysisPanel").classList.add("hidden");
 }
 
+function showOptionOrder(mode) {
+  document.getElementById("optModeSelect").classList.add("hidden");
+  const form = document.getElementById("optionsForm");
+  const holdings = document.getElementById("optionsHoldings");
+  const cancel1 = document.getElementById("cancelOptBtn");
+  const cancel2 = document.getElementById("cancelOptBtn2");
+  if (cancel1) cancel1.classList.remove("hidden");
+  if (cancel2) cancel2.classList.remove("hidden");
+  if (mode === "BUY") {
+    if (form) form.classList.remove("hidden");
+    if (holdings) holdings.classList.add("hidden");
+    updateOptionInfo();
+  } else {
+    if (form) form.classList.add("hidden");
+    if (holdings) {
+      holdings.classList.remove("hidden");
+      renderSellOptions();
+    }
+  }
+}
+
+function hideOptionOrder() {
+  const form = document.getElementById("optionsForm");
+  const holdings = document.getElementById("optionsHoldings");
+  if (form) form.classList.add("hidden");
+  if (holdings) holdings.classList.add("hidden");
+  const cancel1 = document.getElementById("cancelOptBtn");
+  const cancel2 = document.getElementById("cancelOptBtn2");
+  if (cancel1) cancel1.classList.add("hidden");
+  if (cancel2) cancel2.classList.add("hidden");
+  document.getElementById("optModeSelect").classList.remove("hidden");
+}
+
 function updateTradeInfo() {
   const sym = document.getElementById("tradeSymbol").value;
   const weeks = gameState.prices[sym];
@@ -698,7 +731,6 @@ document.addEventListener("DOMContentLoaded", () => {
       if (unlocked && optForm) {
         populateOptionSymbols(companies.filter((c) => !c.isIndex));
         populateOptionDetails();
-        optForm.classList.remove("hidden");
         updateOptionInfo();
         renderSellOptions();
       }
@@ -730,6 +762,19 @@ document.addEventListener("DOMContentLoaded", () => {
     startSellBtn.addEventListener("click", () => showOrderForm("SELL"));
   const cancelTradeBtn = document.getElementById("cancelTradeBtn");
   if (cancelTradeBtn) cancelTradeBtn.addEventListener("click", hideOrderForm);
+
+  const startOptBuyBtn = document.getElementById("startOptBuyBtn");
+  if (startOptBuyBtn)
+    startOptBuyBtn.addEventListener("click", () => showOptionOrder("BUY"));
+  const startOptSellBtn = document.getElementById("startOptSellBtn");
+  if (startOptSellBtn)
+    startOptSellBtn.addEventListener("click", () => showOptionOrder("SELL"));
+  const cancelOptBtn = document.getElementById("cancelOptBtn");
+  if (cancelOptBtn) cancelOptBtn.addEventListener("click", hideOptionOrder);
+  const cancelOptBtn2 = document.getElementById("cancelOptBtn2");
+  if (cancelOptBtn2) cancelOptBtn2.addEventListener("click", hideOptionOrder);
+
+  hideOptionOrder();
 
   const unlocked =
     gameState.rank !== "Novice" ||

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -20,7 +20,11 @@
           <td>$<span id="tCash">0</span></td>
         </tr>
       </table>
-      <div id="optionsForm">
+      <div id="optModeSelect">
+        <button type="button" id="startOptBuyBtn">Buy Order</button>
+        <button type="button" id="startOptSellBtn">Sell Order</button>
+      </div>
+      <div id="optionsForm" class="hidden">
         <h3>Options</h3>
         <label for="optSymbol">Symbol</label><br />
         <select id="optSymbol"></select
@@ -48,11 +52,13 @@
         <div>Premium: $<span id="optPremium">0.00</span></div>
         <div>Total Cost: $<span id="optTotal">0.00</span></div>
         <button type="button" id="optBuyBtn">Buy Option</button>
+        <button type="button" id="cancelOptBtn" class="hidden">Cancel</button>
         <button type="button" onclick="location.href='play.html'">Back to Weekly Summary</button>
       </div>
       <div id="optionsHoldings" class="hidden">
         <h3>Your Options</h3>
         <table id="sellOptionsTable"></table>
+        <button type="button" id="cancelOptBtn2" class="hidden">Cancel</button>
       </div>
       <div id="tradeConfirm" class="confirm-message"></div>
       <table id="tradeHistoryTable"></table>


### PR DESCRIPTION
## Summary
- add Buy Order and Sell Order buttons to options trading page
- allow cancelling options order
- implement JS handlers for buy/sell option modes

## Testing
- `node tests/test_networth_options.js && node tests/test_options_math.js && node tests/test_news_engine.js && node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_68762159e81083258a798c0f9d1b1ce6