### PR TITLE
Add options buy/sell flows

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -271,6 +271,13 @@ select {
   gap: 1rem;
 }
 
+#optionsModeSelect {
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
 #sellHoldingsTable {
   margin: 0.5rem auto;
   border-collapse: collapse;

--- a/docs/js/trade.js
+++ b/docs/js/trade.js
@@ -240,6 +240,33 @@ function hideOrderForm() {
   document.getElementById("analysisPanel").classList.add("hidden");
 }
 
+function showOptionFlow(mode) {
+  const select = document.getElementById("optionsModeSelect");
+  const form = document.getElementById("optionsForm");
+  const holdings = document.getElementById("optionsHoldings");
+  if (select) select.classList.add("hidden");
+  if (mode === "BUY") {
+    if (form) form.classList.remove("hidden");
+    if (holdings) holdings.classList.add("hidden");
+    updateOptionInfo();
+  } else {
+    if (form) form.classList.add("hidden");
+    if (holdings) {
+      holdings.classList.remove("hidden");
+      renderSellOptions();
+    }
+  }
+}
+
+function hideOptionFlow() {
+  const form = document.getElementById("optionsForm");
+  const holdings = document.getElementById("optionsHoldings");
+  const select = document.getElementById("optionsModeSelect");
+  if (form) form.classList.add("hidden");
+  if (holdings) holdings.classList.add("hidden");
+  if (select) select.classList.remove("hidden");
+}
+
 function updateTradeInfo() {
   const sym = document.getElementById("tradeSymbol").value;
   const weeks = gameState.prices[sym];
@@ -698,7 +725,6 @@ document.addEventListener("DOMContentLoaded", () => {
       if (unlocked && optForm) {
         populateOptionSymbols(companies.filter((c) => !c.isIndex));
         populateOptionDetails();
-        optForm.classList.remove("hidden");
         updateOptionInfo();
         renderSellOptions();
       }
@@ -730,6 +756,12 @@ document.addEventListener("DOMContentLoaded", () => {
     startSellBtn.addEventListener("click", () => showOrderForm("SELL"));
   const cancelTradeBtn = document.getElementById("cancelTradeBtn");
   if (cancelTradeBtn) cancelTradeBtn.addEventListener("click", hideOrderForm);
+  const optStartBuyBtn = document.getElementById("optStartBuyBtn");
+  if (optStartBuyBtn)
+    optStartBuyBtn.addEventListener("click", () => showOptionFlow("BUY"));
+  const optStartSellBtn = document.getElementById("optStartSellBtn");
+  if (optStartSellBtn)
+    optStartSellBtn.addEventListener("click", () => showOptionFlow("SELL"));
 
   const unlocked =
     gameState.rank !== "Novice" ||

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -8,9 +8,13 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
   </head>
   <body class="amber">
-    <div class="trade-container">
-      <h1>Trade Stock Options (Cash: $<span id="headerCash">0</span>)</h1>
-      <div id="optionsForm">
+      <div class="trade-container">
+        <h1>Trade Stock Options (Cash: $<span id="headerCash">0</span>)</h1>
+        <div id="optionsModeSelect">
+          <button type="button" id="optStartBuyBtn">Buy Order</button>
+          <button type="button" id="optStartSellBtn">Sell Order</button>
+        </div>
+        <div id="optionsForm" class="hidden">
         <h3>Options</h3>
         <label for="optSymbol">Symbol</label><br />
         <select id="optSymbol"></select


### PR DESCRIPTION
## Summary
- add buttons for choosing buy or sell order flow on the options page
- wire up new option mode controls in `trade.js`
- style the new buttons

## Testing
- `node tests/test_player.js`
- `node tests/test_networth_options.js`
- `node tests/test_options_math.js`
- `node tests/test_news_engine.js`


------
https://chatgpt.com/codex/tasks/task_e_6876246871188325bf057d0b819b4463