### PR TITLE
Update options trading layout

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -147,6 +147,11 @@ button:hover {
   max-width: 540px;
 }
 
+#optionChartWrapper {
+  width: 72%;
+  max-width: 432px;
+}
+
 #marketChart,
 #marketChartMobile,
 #companyChart {
@@ -276,6 +281,18 @@ select {
   display: flex;
   justify-content: center;
   gap: 1rem;
+}
+
+.option-input-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.option-field {
+  text-align: left;
 }
 
 #sellHoldingsTable {

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -20,25 +20,33 @@
         <select id="optSymbol"></select
         ><br />
         <div id="analysisPanel" class="hidden">
-          <div class="chart-wrapper">
+          <div id="optionChartWrapper" class="chart-wrapper">
             <div id="companyChart"></div>
           </div>
         </div>
-        <label for="optType">Type</label><br />
-        <select id="optType">
-          <option value="call">Call</option>
-          <option value="put">Put</option></select
-        ><br />
         <label for="optStockPrice">Current Price</label><br />
         $<span id="optStockPrice">0.00</span><br />
-        <label for="optStrike">Strike</label><br />
-        <select id="optStrike"></select
-        ><br />
-        <label for="optWeeks">Weeks to Expiry</label><br />
-        <select id="optWeeks"></select
-        ><br />
-        <label for="optQty">Contracts</label><br />
-        <input id="optQty" type="number" min="1" value="1" /><br />
+        <div class="option-input-row">
+          <div class="option-field">
+            <label for="optType">Type</label><br />
+            <select id="optType">
+              <option value="call">Call</option>
+              <option value="put">Put</option>
+            </select>
+          </div>
+          <div class="option-field">
+            <label for="optStrike">Strike</label><br />
+            <select id="optStrike"></select>
+          </div>
+          <div class="option-field">
+            <label for="optWeeks">Weeks to Expiry</label><br />
+            <select id="optWeeks"></select>
+          </div>
+          <div class="option-field">
+            <label for="optQty">Contracts</label><br />
+            <input id="optQty" type="number" min="1" value="1" />
+          </div>
+        </div>
         <div>Premium: $<span id="optPremium">0.00</span></div>
         <div>Total Cost: $<span id="optTotal">0.00</span></div>
         <button type="button" id="optBuyBtn">Buy Option</button>


### PR DESCRIPTION
## Summary
- shrink option chart on trading page
- lay out type/strike/weeks/contracts fields in a single row

## Testing
- `node tests/test_options_math.js && node tests/test_networth_options.js && node tests/test_news_engine.js && node tests/test_player.js`


------
https://chatgpt.com/codex/tasks/task_e_68762d010f7c8325b456253657a19691