### PR TITLE
Move Back button on options page

### DIFF
--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -13,6 +13,7 @@
         <div id="optionsModeSelect">
           <button type="button" id="optStartBuyBtn">Buy Order</button>
           <button type="button" id="optStartSellBtn">Sell Order</button>
+          <button type="button" onclick="location.href='play.html'">Back to Weekly Summary</button>
         </div>
         <div id="optionsForm" class="hidden">
         <h3>Options</h3>
@@ -50,7 +51,6 @@
         <div>Premium: $<span id="optPremium">0.00</span></div>
         <div>Total Cost: $<span id="optTotal">0.00</span></div>
         <button type="button" id="optBuyBtn">Execute Order</button>
-        <button type="button" onclick="location.href='play.html'">Back to Weekly Summary</button>
       </div>
       <div id="optionsHoldings" class="hidden">
         <h3>Your Options</h3>


### PR DESCRIPTION
## Summary
- adjust button placement on `trade-options` page

## Testing
- `node tests/test_options_math.js`
- `node tests/test_player.js`
- `node tests/test_networth_options.js`
- `node tests/test_news_engine.js`


------
https://chatgpt.com/codex/tasks/task_e_687632f7dfd083259170d126f5ff276b