### PR TITLE
Fix options order table layout

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -311,17 +311,17 @@ select {
 #tradeHistoryTable {
   margin: 1rem auto;
   border-collapse: collapse;
-  width: auto;
-  max-width: 400px;
+  width: 100%;
+  max-width: 600px;
   text-align: center;
-  margin-left: auto;
-  margin-right: auto;
+  table-layout: fixed;
 }
 
 #tradeHistoryTable th,
 #tradeHistoryTable td {
   border: 1px solid var(--accent-color);
   padding: 0.5rem;
+  font-size: 0.9rem;
 }
 
 .confirm-message {


### PR DESCRIPTION
## Summary
- keep options trade history table centered
- use a slightly smaller font in the options history table

## Testing
- `node tests/test_player.js && node tests/test_options_math.js && node tests/test_networth_options.js && node tests/test_news_engine.js`


------
https://chatgpt.com/codex/tasks/task_e_6876366d6f788325a9a8063772b5fbc8