### PR TITLE
Improve options order page UI

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -70,6 +70,19 @@ button:hover {
   border-color: var(--accent-color);
 }
 
+#sellOptionsTable {
+  margin: 0.5rem auto;
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 600px;
+}
+
+#sellOptionsTable th,
+#sellOptionsTable td {
+  border: 1px solid var(--accent-color);
+  padding: 0.5rem;
+}
+
 #optionsForm button:hover {
   background: var(--accent-color);
   color: #000;

--- a/docs/trade-options.html
+++ b/docs/trade-options.html
@@ -57,6 +57,7 @@
         <table id="sellOptionsTable"></table>
       </div>
       <div id="tradeConfirm" class="confirm-message"></div>
+      <h3>Option Order History</h3>
       <table id="tradeHistoryTable"></table>
     </div>
     <script src="js/storage.js"></script>


### PR DESCRIPTION
## Summary
- make the options sell table use normal table styling
- add a heading for option order history

## Testing
- `node tests/test_options_math.js && node tests/test_networth_options.js && node tests/test_news_engine.js && node tests/test_player.js`

------
https://chatgpt.com/codex/tasks/task_e_687638c4aca4832598142009b5d48203